### PR TITLE
fix: call lua.error directly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,7 @@ lazy_static! {
 }
 
 unsafe fn error(lua: State, err: String){
-    lua.get_global(lua_string!("error"));
-    lua.push_string(err.borrow());
-    lua.call(1, 0);
+   lua.error(err.as_str());
 }
 
 #[lua_function]


### PR DESCRIPTION
Instead of calling the _G.error function from the C API via get_global and call, we can simply call the API function error.