### PR TITLE
docs: README rewrite, LuaLS type stub, crate metadata (P3.1, P3.2, P3.4-cargo)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Assemble release assets
         run: |
           mv bom.json "assets/gm_sysinfo-${{ steps.tag.outputs.tag }}.cdx.json"
+          cp sysinfo.lua assets/sysinfo.lua
           (cd assets && sha256sum -- * > SHA256SUMS)
 
       # Signed SLSA build provenance, queryable later with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 description = "Garry's Mod binary module exposing system information to Lua"
 license = "MIT"
 repository = "https://github.com/JoshPiper/gm_sysinfo"
+readme = "README.md"
+keywords = ["garrysmod", "gmod", "binary-module", "sysinfo"]
 publish = false
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,37 @@
 # gm_sysinfo
 
+[![CI](https://github.com/JoshPiper/gm_sysinfo/actions/workflows/ci.yml/badge.svg)](https://github.com/JoshPiper/gm_sysinfo/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/JoshPiper/gm_sysinfo)](https://github.com/JoshPiper/gm_sysinfo/releases/latest)
+[![License: MIT](https://img.shields.io/github/license/JoshPiper/gm_sysinfo)](LICENSE)
+
 Fetching System Information in Rust to Lua.
 
 ## Installation
 
-Download a copy of the module from the releases (or compile from source)
-Move the downloaded file to `<Garry's Mod Installation>/lua/bin/gm<state>_sysinfo_<platform>.dll`
+Download a copy of the module from the [releases](https://github.com/JoshPiper/gm_sysinfo/releases/latest) page (or [compile from source](#building-from-source)), and move it to:
 
-State can be either cl or sv, for the client and server, respectively.
-Platform can be one of win32, win64, linux, linux64 or osx64 for 32 bit (main branch) Windows, 64 bit (x64 branch) Windows, 32/64 bit Linux, and 64 bit (x64 branch) macOS builds respectively.
+```
+<Garry's Mod Installation>/garrysmod/lua/bin/<filename>
+```
 
-On macOS, downloaded modules carry the quarantine attribute and may be blocked from loading; clear it with `xattr -d com.apple.quarantine <file>`.
+`<filename>` follows the pattern `gm<realm>_sysinfo_<platform>.dll` — note that **every platform's file ends in `.dll`**, including Linux and macOS; that's a Garry's Mod convention, not a mistake.
 
+| Realm | Platform | Filename |
+|---|---|---|
+| Server | Windows, 32-bit (`main` branch) | `gmsv_sysinfo_win32.dll` |
+| Server | Windows, 64-bit (`x86-64` branch) | `gmsv_sysinfo_win64.dll` |
+| Server | Linux, 32-bit (`main` branch) | `gmsv_sysinfo_linux.dll` |
+| Server | Linux, 64-bit (`x86-64` branch) | `gmsv_sysinfo_linux64.dll` |
+| Server | macOS, 64-bit (`x86-64` branch) | `gmsv_sysinfo_osx64.dll` |
+| Client | Windows, 32-bit | `gmcl_sysinfo_win32.dll` |
+| Client | Windows, 64-bit | `gmcl_sysinfo_win64.dll` |
+| Client | Linux, 32-bit | `gmcl_sysinfo_linux.dll` |
+| Client | Linux, 64-bit | `gmcl_sysinfo_linux64.dll` |
+| Client | macOS, 64-bit | `gmcl_sysinfo_osx64.dll` |
+
+Server realm exposes the module to server-side Lua; client realm exposes it to the client console/menu. Install whichever (or both) your use case needs.
+
+On macOS, downloaded files carry the quarantine attribute and may be blocked from loading; clear it with `xattr -d com.apple.quarantine <file>`.
 
 ## Usage
 
@@ -22,6 +42,20 @@ require("sysinfo")
 local hostname = sysinfo.get_host_name() -- "game_server.example.com"
 local cores = sysinfo.get_core_count() -- 8
 ```
+
+An [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file is available — see [Editor support](#editor-support) for autocomplete and inline docs while writing Lua against this module.
+
+## Semantics
+
+- Every value except `get_version()` and `get_build_info()` is **snapshotted once**, when the module loads, not re-read on each call — cheap to call repeatedly, but won't reflect a mid-session change (e.g. hot-added swap).
+- Every getter **raises a Lua error** (rather than returning `nil` or `0`) if its value is unavailable. If a value might legitimately be absent on your target platform — `get_swap()` on a swapless container is the common case — wrap the call in `pcall`:
+
+  ```lua
+  local ok, swap = pcall(sysinfo.get_swap)
+  if ok then
+      print("Swap: " .. swap .. " bytes")
+  end
+  ```
 
 ## API Reference
 
@@ -77,6 +111,29 @@ Returns build provenance for the running binary:
 
 `commit`, `commit_short`, and `dirty` are `nil` if the binary wasn't built from a git checkout. `repository` and `run_url` are empty strings outside of GitHub Actions. If `official` is `false`, or `run_url` doesn't resolve to a real workflow run, treat the binary as unverified — it wasn't built by this project's release pipeline.
 
+## Editor support
+
+A [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file, [`sysinfo.lua`](sysinfo.lua), ships in this repository and as a release asset. It's declarations only (`---@meta`) — never `require()` it in-game. Point your editor at it instead, e.g. in `.luarc.json`:
+
+```json
+{
+    "workspace.library": ["path/to/sysinfo.lua"]
+}
+```
+
+## Building from source
+
+Requires the Rust nightly toolchain pinned in [`rust-toolchain.toml`](rust-toolchain.toml) — `rustup` installs it automatically on first build.
+
+```bash
+git clone https://github.com/JoshPiper/gm_sysinfo
+cd gm_sysinfo
+cargo build --release                    # server realm -> target/release/gm_sysinfo.{dll,so,dylib}
+cargo build --release --features gmcl    # client realm
+```
+
+Cross-compiling to another target needs that target installed (`rustup target add <triple>`) and, for 32-bit Linux specifically, a multilib GCC (`gcc-multilib` on Debian/Ubuntu). See [`.github/workflows/build.yml`](.github/workflows/build.yml) for the exact target/feature matrix CI builds.
+
 ## Verifying a release
 
 Every release binary is built by this repository's GitHub Actions workflow and cryptographically attested. To verify a downloaded file actually came from that pipeline (requires the [GitHub CLI](https://cli.github.com/)):
@@ -95,6 +152,14 @@ Additionally, every binary is built with [`cargo-auditable`](https://github.com/
 cargo install cargo-audit --features=binary-scanning
 cargo audit bin gmsv_sysinfo_linux64.dll
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for how to report a vulnerability.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download a copy of the module from the [releases](https://github.com/JoshPiper/g
 <Garry's Mod Installation>/garrysmod/lua/bin/<filename>
 ```
 
-`<filename>` follows the pattern `gm<realm>_sysinfo_<platform>.dll` — note that **every platform's file ends in `.dll`**, including Linux and macOS; that's a Garry's Mod convention, not a mistake.
+`<filename>` follows the pattern `gm<realm>_sysinfo_<platform>.dll`.
 
 | Realm | Platform | Filename |
 |---|---|---|
@@ -43,7 +43,7 @@ local hostname = sysinfo.get_host_name() -- "game_server.example.com"
 local cores = sysinfo.get_core_count() -- 8
 ```
 
-An [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file is available — see [Editor support](#editor-support) for autocomplete and inline docs while writing Lua against this module.
+An [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file is available - see [Editor support](#editor-support) for autocomplete and inline docs while writing Lua against this module.
 
 ## Semantics
 
@@ -91,7 +91,7 @@ Returns the kernel version name.
 Returns the module's own version, e.g. `"2.0.0"`.
 
 ### `sysinfo.get_build_info(): table`
-Returns build provenance for the running binary:
+Returns build information for the running binary:
 
 ```lua
 {
@@ -109,7 +109,7 @@ Returns build provenance for the running binary:
 }
 ```
 
-`commit`, `commit_short`, and `dirty` are `nil` if the binary wasn't built from a git checkout. `repository` and `run_url` are empty strings outside of GitHub Actions. If `official` is `false`, or `run_url` doesn't resolve to a real workflow run, treat the binary as unverified — it wasn't built by this project's release pipeline.
+`commit`, `commit_short`, and `dirty` are `nil` if the binary wasn't built from a git checkout. `repository` and `run_url` are empty strings outside of GitHub Actions. If `official` is `false`, or `run_url` doesn't resolve to a real workflow run, treat the binary as unverified; it wasn't built by this project's release pipeline.
 
 ## Editor support
 
@@ -123,7 +123,7 @@ A [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file, [`
 
 ## Building from source
 
-Requires the Rust nightly toolchain pinned in [`rust-toolchain.toml`](rust-toolchain.toml) — `rustup` installs it automatically on first build.
+Requires the Rust nightly toolchain pinned in [`rust-toolchain.toml`](rust-toolchain.toml), which `rustup` will automatically install on first build.
 
 ```bash
 git clone https://github.com/JoshPiper/gm_sysinfo
@@ -132,7 +132,9 @@ cargo build --release                    # server realm -> target/release/gm_sys
 cargo build --release --features gmcl    # client realm
 ```
 
-Cross-compiling to another target needs that target installed (`rustup target add <triple>`) and, for 32-bit Linux specifically, a multilib GCC (`gcc-multilib` on Debian/Ubuntu). See [`.github/workflows/build.yml`](.github/workflows/build.yml) for the exact target/feature matrix CI builds.
+Cross-compiling to another target needs that target installed (`rustup target add <triple>`) and, for 32-bit Linux specifically, a multilib GCC (`gcc-multilib` on Debian/Ubuntu).
+See [`.github/workflows/build.yml`](.github/workflows/build.yml) for the exact target/feature matrix CI builds.
+There are some reported pitfalls in cross compiling GMod binaries, so take care during the process.
 
 ## Verifying a release
 
@@ -143,8 +145,8 @@ gh attestation verify gmsv_sysinfo_linux64.dll -R JoshPiper/gm_sysinfo
 ```
 
 Each release also ships:
-- **`SHA256SUMS`** — checksums for every asset in the release.
-- **`gm_sysinfo-<version>.cdx.json`** — a [CycloneDX](https://cyclonedx.org/) software bill of materials for the dependency tree at that version.
+- **`SHA256SUMS`** - checksums for every asset in the release.
+- **`gm_sysinfo-<version>.cdx.json`** - a [CycloneDX](https://cyclonedx.org/) software bill of materials for the dependency tree at that version.
 
 Additionally, every binary is built with [`cargo-auditable`](https://github.com/rust-secure-code/cargo-auditable): the exact dependency versions that went into it are embedded in the file itself, so it can be scanned for known vulnerabilities on its own, without needing the SBOM asset or the source repository:
 

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -9,48 +9,48 @@
 --- @class sysinfo
 sysinfo = {}
 
----Returns the number of physical cores (not threads) on the system.
----Raises a Lua error if the core count could not be read.
+--- Returns the number of physical cores (not threads) on the system.
+--- Raises a Lua error if the core count could not be read.
 --- @return integer
 function sysinfo.get_core_count() end
 
----Returns total system memory, in bytes.
----Raises a Lua error if the memory size could not be read.
+--- Returns total system memory, in bytes.
+--- Raises a Lua error if the memory size could not be read.
 --- @return number
 function sysinfo.get_memory() end
 
----Returns total swap space, in bytes.
----Raises a Lua error if the swap size could not be read (including on
----systems with no swap configured).
+--- Returns total swap space, in bytes.
+--- Raises a Lua error if the swap size could not be read (including on
+--- systems with no swap configured).
 --- @return number
 function sysinfo.get_swap() end
 
----Returns the system name.
----Raises a Lua error if the system name could not be read.
+--- Returns the system name.
+--- Raises a Lua error if the system name could not be read.
 --- @return string
 function sysinfo.get_system_name() end
 
----Returns the system DNS name.
----Raises a Lua error if the host name could not be read.
+--- Returns the system DNS name.
+--- Raises a Lua error if the host name could not be read.
 --- @return string
 function sysinfo.get_host_name() end
 
----Returns the system version's long name.
----Raises a Lua error if the version could not be read.
+--- Returns the system version's long name.
+--- Raises a Lua error if the version could not be read.
 --- @return string
 function sysinfo.get_system_long_version() end
 
----Returns the system version name.
----Raises a Lua error if the version could not be read.
+--- Returns the system version name.
+--- Raises a Lua error if the version could not be read.
 --- @return string
 function sysinfo.get_system_version() end
 
----Returns the kernel version name.
----Raises a Lua error if the kernel version could not be read.
+--- Returns the kernel version name.
+--- Raises a Lua error if the kernel version could not be read.
 --- @return string
 function sysinfo.get_kernel_version() end
 
----Returns the module's own version, e.g. "2.0.0".
+--- Returns the module's own version, e.g. "2.0.0".
 --- @return string
 function sysinfo.get_version() end
 
@@ -67,8 +67,8 @@ function sysinfo.get_version() end
 --- @field repository string # empty outside of GitHub Actions
 --- @field run_url string # empty outside of GitHub Actions
 
----Returns build provenance for the running binary. See the README's
----"Verifying a release" section before trusting `official`, `commit`,
----or `run_url` for anything security-sensitive.
+--- Returns build provenance for the running binary. See the README's
+--- "Verifying a release" section before trusting `official`, `commit`,
+--- or `run_url` for anything security-sensitive.
 --- @return SysinfoBuildInfo
 function sysinfo.get_build_info() end

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -1,0 +1,74 @@
+---@meta
+
+-- Type definitions for gm_sysinfo, for use with the Lua Language Server
+-- (https://github.com/LuaLS/lua-language-server). This file declares the
+-- shape of the API only; it has no runtime behaviour and must never be
+-- require()'d in-game. Point your editor at it instead -- see the
+-- "Editor support" section of the README.
+
+---@class sysinfo
+sysinfo = {}
+
+---Returns the number of physical cores (not threads) on the system.
+---Raises a Lua error if the core count could not be read.
+---@return integer
+function sysinfo.get_core_count() end
+
+---Returns total system memory, in bytes.
+---Raises a Lua error if the memory size could not be read.
+---@return number
+function sysinfo.get_memory() end
+
+---Returns total swap space, in bytes.
+---Raises a Lua error if the swap size could not be read (including on
+---systems with no swap configured).
+---@return number
+function sysinfo.get_swap() end
+
+---Returns the system name.
+---Raises a Lua error if the system name could not be read.
+---@return string
+function sysinfo.get_system_name() end
+
+---Returns the system DNS name.
+---Raises a Lua error if the host name could not be read.
+---@return string
+function sysinfo.get_host_name() end
+
+---Returns the system version's long name.
+---Raises a Lua error if the version could not be read.
+---@return string
+function sysinfo.get_system_long_version() end
+
+---Returns the system version name.
+---Raises a Lua error if the version could not be read.
+---@return string
+function sysinfo.get_system_version() end
+
+---Returns the kernel version name.
+---Raises a Lua error if the kernel version could not be read.
+---@return string
+function sysinfo.get_kernel_version() end
+
+---Returns the module's own version, e.g. "2.0.0".
+---@return string
+function sysinfo.get_version() end
+
+---@class SysinfoBuildInfo
+---@field version string
+---@field commit string? # nil if not built from a git checkout
+---@field commit_short string? # nil if not built from a git checkout
+---@field dirty boolean? # nil if unknown
+---@field built_at string
+---@field target string
+---@field realm "sv"|"cl"
+---@field rustc_version string
+---@field official boolean # true only for binaries built by this project's CI
+---@field repository string # empty outside of GitHub Actions
+---@field run_url string # empty outside of GitHub Actions
+
+---Returns build provenance for the running binary. See the README's
+---"Verifying a release" section before trusting `official`, `commit`,
+---or `run_url` for anything security-sensitive.
+---@return SysinfoBuildInfo
+function sysinfo.get_build_info() end

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -1,4 +1,4 @@
----@meta
+--- @meta
 
 -- Type definitions for gm_sysinfo, for use with the Lua Language Server
 -- (https://github.com/LuaLS/lua-language-server). This file declares the
@@ -6,69 +6,69 @@
 -- require()'d in-game. Point your editor at it instead -- see the
 -- "Editor support" section of the README.
 
----@class sysinfo
+--- @class sysinfo
 sysinfo = {}
 
 ---Returns the number of physical cores (not threads) on the system.
 ---Raises a Lua error if the core count could not be read.
----@return integer
+--- @return integer
 function sysinfo.get_core_count() end
 
 ---Returns total system memory, in bytes.
 ---Raises a Lua error if the memory size could not be read.
----@return number
+--- @return number
 function sysinfo.get_memory() end
 
 ---Returns total swap space, in bytes.
 ---Raises a Lua error if the swap size could not be read (including on
 ---systems with no swap configured).
----@return number
+--- @return number
 function sysinfo.get_swap() end
 
 ---Returns the system name.
 ---Raises a Lua error if the system name could not be read.
----@return string
+--- @return string
 function sysinfo.get_system_name() end
 
 ---Returns the system DNS name.
 ---Raises a Lua error if the host name could not be read.
----@return string
+--- @return string
 function sysinfo.get_host_name() end
 
 ---Returns the system version's long name.
 ---Raises a Lua error if the version could not be read.
----@return string
+--- @return string
 function sysinfo.get_system_long_version() end
 
 ---Returns the system version name.
 ---Raises a Lua error if the version could not be read.
----@return string
+--- @return string
 function sysinfo.get_system_version() end
 
 ---Returns the kernel version name.
 ---Raises a Lua error if the kernel version could not be read.
----@return string
+--- @return string
 function sysinfo.get_kernel_version() end
 
 ---Returns the module's own version, e.g. "2.0.0".
----@return string
+--- @return string
 function sysinfo.get_version() end
 
----@class SysinfoBuildInfo
----@field version string
----@field commit string? # nil if not built from a git checkout
----@field commit_short string? # nil if not built from a git checkout
----@field dirty boolean? # nil if unknown
----@field built_at string
----@field target string
----@field realm "sv"|"cl"
----@field rustc_version string
----@field official boolean # true only for binaries built by this project's CI
----@field repository string # empty outside of GitHub Actions
----@field run_url string # empty outside of GitHub Actions
+--- @class SysinfoBuildInfo
+--- @field version string
+--- @field commit string? # nil if not built from a git checkout
+--- @field commit_short string? # nil if not built from a git checkout
+--- @field dirty boolean? # nil if unknown
+--- @field built_at string
+--- @field target string
+--- @field realm "sv"|"cl"
+--- @field rustc_version string
+--- @field official boolean # true only for binaries built by this project's CI
+--- @field repository string # empty outside of GitHub Actions
+--- @field run_url string # empty outside of GitHub Actions
 
 ---Returns build provenance for the running binary. See the README's
 ---"Verifying a release" section before trusting `official`, `commit`,
 ---or `run_url` for anything security-sensitive.
----@return SysinfoBuildInfo
+--- @return SysinfoBuildInfo
 function sysinfo.get_build_info() end


### PR DESCRIPTION
Implements the README rewrite, LuaLS type definitions, and Cargo.toml metadata items from **P3** of the production-readiness review. CONTRIBUTING.md and SECURITY.md are deliberately out of scope here — going up as separate PRs.

## README

- CI / latest-release / license badges
- Installation section restructured around an explicit realm × platform → filename table (10 rows, matching the build matrix), plus an explicit callout that every platform's file ends in `.dll` — including Linux and macOS, which trips people up
- New **Semantics** section: values are snapshotted once at module load (not re-read per call), and every getter raises rather than returning `nil`/`0` — with a `pcall` example for the legitimately-optional case (`get_swap()` on a swapless box)
- New **Building from source** section: pinned-nightly note, both realm build commands, and a pointer to `build.yml` for the exact cross-compile matrix
- New **Editor support** section pointing at the LuaLS stub
- Links to CONTRIBUTING.md / SECURITY.md (added by the other two PRs — harmless 404s until those merge, all three are going up together)

## `sysinfo.lua`

A `---@meta` [LuaLS](https://github.com/LuaLS/lua-language-server) type stub covering every exported function, including a `SysinfoBuildInfo` class for `get_build_info()`'s return shape. Declarations only — explicitly documented as never-`require()`'d at runtime. Shipped both in-repo and copied into `assets/` in `release-plz.yml`'s asset-packaging step, so it's attached to every release alongside the binaries.

## Cargo.toml

Added `readme` and `keywords`. Skipped `categories` (would need a real crates.io category slug for a crate that's never published — not worth the guesswork) and `authors` (wasn't present before; not adding without asking).

## Verification

- `cargo check`: clean (metadata-only Cargo.toml changes)
- `release-plz.yml` YAML validated with a parser
- No local Lua interpreter available to syntax-check `sysinfo.lua` directly; it's plain declarations (comments + empty function bodies), low syntactic risk, and not loaded by any test path — flagging this as the one unverified piece rather than silently asserting it's fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)
