### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,21 @@
 # Contributing to gm_sysinfo
 
-A'ite, thanks for taking a look. This is a small project so the process is light — but there's one rule below that isn't optional, and it's worth reading before you open a PR rather than after CI's confused you.
-
----
-
 ## Purpose
 
 This document exists to:
-- Explain the one rule that actually matters, and why it's not negotiable.
-- Set out what CI gates a PR on, so you're not guessing.
+- Explain how commit messages drive versioning and releases.
+- Set out what CI gates a PR on.
 - Save you rediscovering the local build/lint/test setup by trial and error.
 
 ---
 
-## Commit messages must be Conventional Commits
+## Conventional Commits
 
-Not a style preference. [release-plz](https://release-plz.dev) reads your commit messages to decide whether a release happens, what version it gets, and what the changelog says. Get the type wrong and nothing breaks loudly — nothing happens at all, which is worse. No release, no changelog entry, no warning. The commit just sits there looking normal.
+release-plz reads commit messages to drive versioning, changelogs, and releases.
 
 Format: `<type>[optional scope]: <description>`
 
-**Types that matter to the release process:**
+Types:
 
 | Type | Effect |
 |---|---|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,25 @@
 # Contributing to gm_sysinfo
 
-Thanks for taking a look. This is a small project, so the process is deliberately light — but there's one rule that isn't optional.
+A'ite, thanks for taking a look. This is a small project so the process is light — but there's one rule below that isn't optional, and it's worth reading before you open a PR rather than after CI's confused you.
+
+---
+
+## Purpose
+
+This document exists to:
+- Explain the one rule that actually matters, and why it's not negotiable.
+- Set out what CI gates a PR on, so you're not guessing.
+- Save you rediscovering the local build/lint/test setup by trial and error.
+
+---
 
 ## Commit messages must be Conventional Commits
 
-This is not a style preference. [release-plz](https://release-plz.dev) reads your commit messages to decide whether a release is needed, what the next version number is, and what goes in the changelog. A commit that doesn't follow the format doesn't get you a broken release — it gets you **no release at all**, silently.
+Not a style preference. [release-plz](https://release-plz.dev) reads your commit messages to decide whether a release happens, what version it gets, and what the changelog says. Get the type wrong and nothing breaks loudly — nothing happens at all, which is worse. No release, no changelog entry, no warning. The commit just sits there looking normal.
 
 Format: `<type>[optional scope]: <description>`
 
-The types that matter to the release process:
+**Types that matter to the release process:**
 
 | Type | Effect |
 |---|---|
@@ -30,16 +41,35 @@ BREAKING CHANGE: sysinfo.get_memory() and sysinfo.get_swap() now
 return bytes. Previously they returned KiB.
 ```
 
-If a PR mixes several logical changes, prefer several small commits with correct types over one commit with the "biggest" type — release-plz aggregates all of them for the changelog, and smaller commits review better too.
+If a PR mixes several logical changes, split the commits by type rather than reaching for whichever tag sounds biggest. release-plz aggregates every commit into the changelog regardless, so there's no upside to lumping it all under one `feat:` — and smaller commits review better besides.
 
-## What happens after you open a PR
+---
 
-- `ci.yml` runs `cargo fmt --check`, `cargo clippy -D warnings` (both realms), the full 10-target build matrix, and [GLuaTest](https://github.com/CFC-Servers/GLuaTest) against real Garry's Mod server instances. All of it needs to pass before merge.
-- You don't need to bump the version, edit `CHANGELOG.md`, or create a tag. Once your PR merges to `main`, release-plz opens (or updates) a standing release PR by itself, from your commit messages. A maintainer merges that when it's time to ship — see the root README's semantics/release notes for why that's a deliberate gate, not an oversight.
+## What CI actually gates
+
+`ci.yml` runs, on every PR:
+- `cargo fmt --check`
+- `cargo clippy -D warnings`, both realms
+- The full 10-target build matrix
+- [GLuaTest](https://github.com/CFC-Servers/GLuaTest) against real Garry's Mod server instances
+
+All of it needs to pass. There's no merging around a red check.
+
+---
+
+## What you don't need to do
+
+- Bump the version.
+- Touch `CHANGELOG.md`.
+- Create a tag.
+
+release-plz does all three off your commit messages once your PR's on `main`. If you catch yourself editing the version field in `Cargo.toml`, stop — that's not your job any more, and it'll just conflict with the release PR release-plz maintains automatically. A maintainer merges that when it's time to ship; see the root README for why that's a deliberate gate rather than an oversight.
+
+---
 
 ## Local setup
 
-The pinned nightly toolchain in [`rust-toolchain.toml`](rust-toolchain.toml) is picked up automatically by `rustup` — you shouldn't need to install anything by hand beyond `rustup` itself.
+The pinned nightly toolchain in [`rust-toolchain.toml`](rust-toolchain.toml) gets picked up by `rustup` automatically — nothing to install by hand beyond `rustup` itself.
 
 ```bash
 cargo build --release                    # server realm
@@ -49,7 +79,7 @@ cargo clippy --all-targets -- -D warnings
 cargo clippy --all-targets --features gmcl -- -D warnings
 ```
 
-Run both clippy invocations — the two realms compile different code paths (see the `gmcl` feature gate in `src/lib.rs`), and CI lints both.
+Run both clippy invocations, not just one — the two realms compile different code paths (see the `gmcl` feature gate in `src/lib.rs`), and CI lints both.
 
 Cross-compiling to a specific release target needs that target installed:
 
@@ -58,19 +88,23 @@ rustup target add x86_64-unknown-linux-gnu
 cargo build --release --target x86_64-unknown-linux-gnu
 ```
 
-32-bit Linux targets additionally need a multilib GCC (`sudo apt-get install gcc-multilib` on Debian/Ubuntu).
+32-bit Linux targets also need a multilib GCC (`sudo apt-get install gcc-multilib` on Debian/Ubuntu).
 
 ### Running the Lua tests locally
 
-CI runs [GLuaTest](https://github.com/CFC-Servers/GLuaTest) against the built server module automatically on every PR (`.github/workflows/ci.yml`). Running it locally requires Docker; see GLuaTest's own documentation for a local invocation. Test specs live in `lua/tests/sysinfo/`.
+CI runs [GLuaTest](https://github.com/CFC-Servers/GLuaTest) against the built server module on every PR (`.github/workflows/ci.yml`). Running it locally needs Docker — see GLuaTest's own docs for the local invocation. Specs live in `lua/tests/sysinfo/`.
+
+---
 
 ## Code style
 
-- No comments explaining *what* the code does — names should do that. A comment earns its place only when it captures a non-obvious *why*: a hidden constraint, a workaround, a decision that would otherwise look like a mistake on review.
-- Keep the `unsafe` surface exactly as small as it already is. If you're adding a new Lua-exported function, follow the existing `#[lua_function]` pattern in `src/lib.rs` rather than introducing a new calling convention.
-- Prefer extending the existing macros (`err!`, `export_lua_function!`, `set_field!`) over hand-rolling a one-off when a new getter fits the same shape as its neighbours.
-- Run `cargo fmt` before pushing — CI enforces it and won't auto-fix it for you.
+- No comments explaining *what* the code does — the names already do that. A comment earns its place only when it captures a non-obvious *why*: a hidden constraint, a workaround, a decision that would otherwise look like a mistake to a reviewer.
+- Keep the `unsafe` surface exactly as small as it is today. Adding a new Lua-exported function? Follow the existing `#[lua_function]` pattern in `src/lib.rs` rather than inventing a new calling convention.
+- A new getter that fits the shape of its neighbours extends the existing macros (`err!`, `export_lua_function!`, `set_field!`). It doesn't get a hand-rolled one-off.
+- Run `cargo fmt` before you push. CI enforces it, and it will not fix it for you.
+
+---
 
 ## Reporting a security issue
 
-Don't open a public issue for that — see [SECURITY.md](SECURITY.md).
+Don't put it in a PR or an issue. See [SECURITY.md](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to gm_sysinfo
+
+Thanks for taking a look. This is a small project, so the process is deliberately light — but there's one rule that isn't optional.
+
+## Commit messages must be Conventional Commits
+
+This is not a style preference. [release-plz](https://release-plz.dev) reads your commit messages to decide whether a release is needed, what the next version number is, and what goes in the changelog. A commit that doesn't follow the format doesn't get you a broken release — it gets you **no release at all**, silently.
+
+Format: `<type>[optional scope]: <description>`
+
+The types that matter to the release process:
+
+| Type | Effect |
+|---|---|
+| `fix:` | Patch release (`x.y.Z`) |
+| `feat:` | Minor release (`x.Y.0`) |
+| `feat!:` or a `BREAKING CHANGE:` footer | Major release (`X.0.0`) |
+| `chore:`, `build:`, `ci:`, `docs:`, `test:`, `refactor:`, `style:` | No release triggered on their own |
+
+Examples:
+
+```
+fix: correct the get_host_name error message
+
+feat: expose sysinfo.get_build_info()
+
+feat!: return memory and swap in bytes instead of KiB
+
+BREAKING CHANGE: sysinfo.get_memory() and sysinfo.get_swap() now
+return bytes. Previously they returned KiB.
+```
+
+If a PR mixes several logical changes, prefer several small commits with correct types over one commit with the "biggest" type — release-plz aggregates all of them for the changelog, and smaller commits review better too.
+
+## What happens after you open a PR
+
+- `ci.yml` runs `cargo fmt --check`, `cargo clippy -D warnings` (both realms), the full 10-target build matrix, and [GLuaTest](https://github.com/CFC-Servers/GLuaTest) against real Garry's Mod server instances. All of it needs to pass before merge.
+- You don't need to bump the version, edit `CHANGELOG.md`, or create a tag. Once your PR merges to `main`, release-plz opens (or updates) a standing release PR by itself, from your commit messages. A maintainer merges that when it's time to ship — see the root README's semantics/release notes for why that's a deliberate gate, not an oversight.
+
+## Local setup
+
+The pinned nightly toolchain in [`rust-toolchain.toml`](rust-toolchain.toml) is picked up automatically by `rustup` — you shouldn't need to install anything by hand beyond `rustup` itself.
+
+```bash
+cargo build --release                    # server realm
+cargo build --release --features gmcl    # client realm
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo clippy --all-targets --features gmcl -- -D warnings
+```
+
+Run both clippy invocations — the two realms compile different code paths (see the `gmcl` feature gate in `src/lib.rs`), and CI lints both.
+
+Cross-compiling to a specific release target needs that target installed:
+
+```bash
+rustup target add x86_64-unknown-linux-gnu
+cargo build --release --target x86_64-unknown-linux-gnu
+```
+
+32-bit Linux targets additionally need a multilib GCC (`sudo apt-get install gcc-multilib` on Debian/Ubuntu).
+
+### Running the Lua tests locally
+
+CI runs [GLuaTest](https://github.com/CFC-Servers/GLuaTest) against the built server module automatically on every PR (`.github/workflows/ci.yml`). Running it locally requires Docker; see GLuaTest's own documentation for a local invocation. Test specs live in `lua/tests/sysinfo/`.
+
+## Code style
+
+- No comments explaining *what* the code does — names should do that. A comment earns its place only when it captures a non-obvious *why*: a hidden constraint, a workaround, a decision that would otherwise look like a mistake on review.
+- Keep the `unsafe` surface exactly as small as it already is. If you're adding a new Lua-exported function, follow the existing `#[lua_function]` pattern in `src/lib.rs` rather than introducing a new calling convention.
+- Prefer extending the existing macros (`err!`, `export_lua_function!`, `set_field!`) over hand-rolling a one-off when a new getter fits the same shape as its neighbours.
+- Run `cargo fmt` before pushing — CI enforces it and won't auto-fix it for you.
+
+## Reporting a security issue
+
+Don't open a public issue for that — see [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
Adds a contributor guide. Standalone from the other two docs PRs (#12 for README/LuaLS stub, and the upcoming SECURITY.md PR) -- can merge in any order, though the README's new "Contributing" link and this file's own "Reporting a security issue" link to `SECURITY.md` won't resolve until that one's in too.

## What it covers

- **Conventional Commits are load-bearing, not stylistic** -- spelled out explicitly, since this is the one thing a contributor genuinely needs to know that isn't discoverable by reading the code: release-plz drives version bumps/changelog/releases off commit message types, and a misformatted commit doesn't fail loudly, it just never triggers a release.
- What CI actually gates a PR on (fmt, clippy both realms, the 10-target build matrix, GLuaTest).
- That version bumps/changelog/tagging are automatic -- a contributor should never hand-edit those.
- Local build/lint commands for both realms, plus cross-compilation and the 32-bit Linux multilib requirement.
- Where the Lua test specs live and how CI runs them (Docker via GLuaTest).
- Code style notes specific to this codebase: minimal `unsafe` surface, extend existing macros rather than one-off patterns, no what-comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
