### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,15 +3,15 @@
 ## Purpose
 
 This document exists to:
-- Say plainly where to send a vulnerability report, and where not to.
-- Draw the line between what's this project's problem and what isn't.
-- Set expectations that are actually true, rather than the boilerplate ones.
+- Say where to send a vulnerability report.
+- Define what's in scope and what isn't.
+- Set honest expectations for response time.
 
 ---
 
 ## Supported versions
 
-Latest release only. There's no maintained LTS branch, and there isn't going to be — if a fix is needed, it ships on top of current `main` in the next release.
+Latest release only. No maintained LTS branch — a fix ships on top of current `main` in the next release.
 
 ---
 
@@ -19,31 +19,27 @@ Latest release only. There's no maintained LTS branch, and there isn't going to 
 
 **Don't open a public issue for this.**
 
-Use GitHub's private vulnerability reporting instead:
-
-**[Report a vulnerability](https://github.com/JoshPiper/gm_sysinfo/security/advisories/new)**
-
-That opens a draft security advisory visible only to me and you, with room to sort the issue out before any of it is public. If you'd rather not use GitHub for it, open a normal issue asking for another way to reach me — just don't put report details in it.
+**[Report a vulnerability](https://github.com/JoshPiper/gm_sysinfo/security/advisories/new)** — GitHub's private advisory flow, visible only to me and you until it's resolved. No GitHub? Open a normal issue asking for another contact, without report details in it.
 
 Include, if you can:
 - The version, or `get_build_info()` output, of the binary affected.
 - Steps to reproduce, or a minimal repro.
-- What you think the impact is — crash, memory disclosure, arbitrary code execution in the game process, whatever it is.
+- The impact — crash, memory disclosure, arbitrary code execution in the game process, whatever it is.
 
 ---
 
 ## Scope
 
-**In scope:**
-- The Rust module itself (`src/`) and its build script (`build.rs`).
-- The release pipeline (`.github/workflows/`) — a malicious binary ending up attached to a release under this project's name is very much in scope.
-- A vulnerable dependency version actually shipped in a release binary. See [Verifying a release](README.md#verifying-a-release) for how to check what's in one.
+In scope:
+- The Rust module (`src/`) and its build script (`build.rs`).
+- The release pipeline (`.github/workflows/`) — a malicious binary attached to a release under this project's name.
+- A vulnerable dependency actually shipped in a release binary. See [Verifying a release](README.md#verifying-a-release) for how to check what's in one.
 
-**Out of scope:**
-- Garry's Mod itself, Rust/rustc, or a dependency vulnerability with no exploitation path through this module. Report those upstream. Flag them here too if you're not sure who else should know — a dependency bump is a one-line fix on this end regardless of where the report lands.
+Out of scope:
+- Garry's Mod itself, Rust/rustc, or a dependency vulnerability with no exploitation path through this module. Report upstream. Flag it here too if unsure — a dependency bump is a one-line fix on this end regardless.
 
 ---
 
 ## What to expect
 
-This is a spare-time project, not a funded security-critical product, and I'm not going to pretend there's an SLA when there isn't one. A credible report gets triaged as fast as I can reasonably manage. In return, give me a fair window to ship a fix before disclosing publicly — coordinated disclosure, not a race. Credit goes in the release notes if you want it.
+No SLA — spare-time project. Credible reports get triaged fast. Give a fair window before public disclosure; credit goes in the release notes if you want it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,32 +1,49 @@
 # Security Policy
 
+## Purpose
+
+This document exists to:
+- Say plainly where to send a vulnerability report, and where not to.
+- Draw the line between what's this project's problem and what isn't.
+- Set expectations that are actually true, rather than the boilerplate ones.
+
+---
+
 ## Supported versions
 
-Only the **latest release** is supported. There are no maintained LTS branches — if a fix is needed, it ships in the next release, built on top of current `main`.
+Latest release only. There's no maintained LTS branch, and there isn't going to be — if a fix is needed, it ships on top of current `main` in the next release.
+
+---
 
 ## Reporting a vulnerability
 
-**Please don't open a public issue for a security report.**
+**Don't open a public issue for this.**
 
 Use GitHub's private vulnerability reporting instead:
 
 **[Report a vulnerability](https://github.com/JoshPiper/gm_sysinfo/security/advisories/new)**
 
-This opens a draft security advisory visible only to the maintainer and you, with room to discuss and fix the issue before anything is public. If you'd rather not use GitHub for this, open a regular issue asking for another contact channel — just don't put report details in it.
+That opens a draft security advisory visible only to me and you, with room to sort the issue out before any of it is public. If you'd rather not use GitHub for it, open a normal issue asking for another way to reach me — just don't put report details in it.
 
-Please include, if you can:
-- The version (or commit/`get_build_info()` output) affected.
+Include, if you can:
+- The version, or `get_build_info()` output, of the binary affected.
 - Steps to reproduce, or a minimal repro.
-- What you think the impact is (e.g. crash, memory disclosure, arbitrary code execution in the game process).
+- What you think the impact is — crash, memory disclosure, arbitrary code execution in the game process, whatever it is.
 
-## What's in scope
+---
 
+## Scope
+
+**In scope:**
 - The Rust module itself (`src/`) and its build script (`build.rs`).
-- The release pipeline (`.github/workflows/`) — e.g. anything that could let a malicious binary get attached to a release under this project's name.
-- A vulnerable dependency version actually shipped in a release binary — see [`Verifying a release`](README.md#verifying-a-release) for how to check what's in one.
+- The release pipeline (`.github/workflows/`) — a malicious binary ending up attached to a release under this project's name is very much in scope.
+- A vulnerable dependency version actually shipped in a release binary. See [Verifying a release](README.md#verifying-a-release) for how to check what's in one.
 
-**Out of scope**: vulnerabilities in Garry's Mod itself, in Rust/rustc, or in a dependency that don't have a specific exploitation path through this module — those are better reported upstream. Feel free to flag them here too if you're not sure who else should know; a dependency bump is a one-line fix on this end regardless.
+**Out of scope:**
+- Garry's Mod itself, Rust/rustc, or a dependency vulnerability with no exploitation path through this module. Report those upstream. Flag them here too if you're not sure who else should know — a dependency bump is a one-line fix on this end regardless of where the report lands.
+
+---
 
 ## What to expect
 
-This is a small project maintained in spare time, not a funded security-critical product — there's no formal SLA. That said, a credible report will be acknowledged and triaged as quickly as reasonably possible, and coordinated disclosure is genuinely appreciated: please give a reasonable window to ship a fix before disclosing publicly. Credit is happily given in the release notes if you'd like it.
+This is a spare-time project, not a funded security-critical product, and I'm not going to pretend there's an SLA when there isn't one. A credible report gets triaged as fast as I can reasonably manage. In return, give me a fair window to ship a fix before disclosing publicly — coordinated disclosure, not a race. Credit goes in the release notes if you want it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported versions
+
+Only the **latest release** is supported. There are no maintained LTS branches — if a fix is needed, it ships in the next release, built on top of current `main`.
+
+## Reporting a vulnerability
+
+**Please don't open a public issue for a security report.**
+
+Use GitHub's private vulnerability reporting instead:
+
+**[Report a vulnerability](https://github.com/JoshPiper/gm_sysinfo/security/advisories/new)**
+
+This opens a draft security advisory visible only to the maintainer and you, with room to discuss and fix the issue before anything is public. If you'd rather not use GitHub for this, open a regular issue asking for another contact channel — just don't put report details in it.
+
+Please include, if you can:
+- The version (or commit/`get_build_info()` output) affected.
+- Steps to reproduce, or a minimal repro.
+- What you think the impact is (e.g. crash, memory disclosure, arbitrary code execution in the game process).
+
+## What's in scope
+
+- The Rust module itself (`src/`) and its build script (`build.rs`).
+- The release pipeline (`.github/workflows/`) — e.g. anything that could let a malicious binary get attached to a release under this project's name.
+- A vulnerable dependency version actually shipped in a release binary — see [`Verifying a release`](README.md#verifying-a-release) for how to check what's in one.
+
+**Out of scope**: vulnerabilities in Garry's Mod itself, in Rust/rustc, or in a dependency that don't have a specific exploitation path through this module — those are better reported upstream. Feel free to flag them here too if you're not sure who else should know; a dependency bump is a one-line fix on this end regardless.
+
+## What to expect
+
+This is a small project maintained in spare time, not a funded security-critical product — there's no formal SLA. That said, a credible report will be acknowledged and triaged as quickly as reasonably possible, and coordinated disclosure is genuinely appreciated: please give a reasonable window to ship a fix before disclosing publicly. Credit is happily given in the release notes if you'd like it.


### PR DESCRIPTION
Adds a security policy. Standalone from the other two docs PRs (#12, #13) -- the README and CONTRIBUTING.md both link to `SECURITY.md`, which won't resolve until this merges too, but nothing here depends on them.

## What it covers

- **Where to report**: GitHub's private vulnerability reporting UI, not a public issue. I checked -- it's already enabled on the repo (`gh api repos/JoshPiper/gm_sysinfo/private-vulnerability-reporting` returns `{"enabled":true}`), so the link in this file actually works today rather than assuming a setting that isn't on.
- **Scope**: the module source, `build.rs`, and the release pipeline are in scope (including "could a malicious binary get attached to a release under this project's name" -- directly relevant given P2's attestation work). Garry's Mod itself, rustc, and dependency CVEs without a specific exploitation path through this module are out of scope, with a note that they're still welcome to flag here if unsure where else to send them.
- **Expectations**: deliberately honest that this is a spare-time project with no formal SLA, rather than implying a response guarantee the maintainer can't actually commit to. Coordinated disclosure requested; credit offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
