### PR TITLE
fix!: get_swap() no longer raises when no swap is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ An [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file is
 ## Semantics
 
 - Every value except `get_version()` and `get_build_info()` is **snapshotted once**, when the module loads, not re-read on each call — cheap to call repeatedly, but won't reflect a mid-session change (e.g. hot-added swap).
-- Every getter **raises a Lua error** (rather than returning `nil` or `0`) if its value is unavailable. If a value might legitimately be absent on your target platform — `get_swap()` on a swapless container is the common case — wrap the call in `pcall`:
+- Most getters **raise a Lua error** (rather than returning `nil`) if their value couldn't be read at all. A handful return `0` instead where zero is itself a legitimate answer rather than a failure signal — `get_swap()` on a swapless host being the common case — see each function's entry in the API reference below for which rule applies. If you're calling something platform-specific that might not apply to the host you're on, wrap it in `pcall`:
 
   ```lua
-  local ok, swap = pcall(sysinfo.get_swap)
+  local ok, value = pcall(sysinfo.get_kernel_version)
   if ok then
-      print("Swap: " .. swap .. " bytes")
+      print("Kernel: " .. value)
   end
   ```
 
@@ -70,7 +70,7 @@ local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ```
 
 ### `sysinfo.get_swap(): number`
-Returns total swap space, in bytes.
+Returns total swap space, in bytes. Returns `0` (never raises) if the host has no swap configured — that's a legitimate, common state, not a read failure.
   
 ### `sysinfo.get_system_name(): string`
 Returns the system name.

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -33,7 +33,7 @@ return {
                 -- never raise.
                 local swap = sysinfo.get_swap()
                 expect( swap ).to.beA( "number" )
-                expect( swap ).to.beGreaterThan( -1 )
+                expect( swap ).toNot.beLessThan( 0 )
             end
         },
         {

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -26,14 +26,14 @@ return {
             end
         },
         {
-            name = "Reports swap as positive bytes, or raises when absent",
+            name = "Reports swap as non-negative bytes, never raising",
             func = function()
-                -- Containers commonly have no swap; the API contract is to
-                -- raise a Lua error rather than return 0.
-                local ok, swap = pcall( sysinfo.get_swap )
-                if ok then
-                    expect( swap ).to.beGreaterThan( 0 )
-                end
+                -- 0 is a legitimate answer here (no swap configured) rather
+                -- than a failure -- unlike the other getters, this must
+                -- never raise.
+                local swap = sysinfo.get_swap()
+                expect( swap ).to.beA( "number" )
+                expect( swap ).to.beGreaterThan( -1 )
             end
         },
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,7 @@ unsafe fn get_memory(lua: State) -> i32 {
 
 #[lua_function]
 unsafe fn get_swap(lua: State) -> i32 {
-    // 0 is legitimate here -- unlike memory, plenty of real hosts run with
-    // no swap at all, and sysinfo can't tell "no swap" from "failed to
-    // read" either way. Erroring on it would misreport a common, valid setup.
+    // 0 is legitimate -- sysinfo can't tell "no swap" from "failed to read".
     lua.push_number(INFO.total_swap as f64);
     1
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,10 @@ unsafe fn get_memory(lua: State) -> i32 {
 
 #[lua_function]
 unsafe fn get_swap(lua: State) -> i32 {
-    if INFO.total_swap == 0 {
-        error(lua, err!("read the system swap space"));
-    }
-
+    // Unlike memory, 0 is a legitimate value here -- plenty of real hosts
+    // (containers, VPSes) run with no swap configured at all. sysinfo can't
+    // distinguish "no swap" from "failed to read" either way, so treating 0
+    // as an error would misreport a common, valid configuration.
     lua.push_number(INFO.total_swap as f64);
     1
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,9 @@ unsafe fn get_memory(lua: State) -> i32 {
 
 #[lua_function]
 unsafe fn get_swap(lua: State) -> i32 {
-    // Unlike memory, 0 is a legitimate value here -- plenty of real hosts
-    // (containers, VPSes) run with no swap configured at all. sysinfo can't
-    // distinguish "no swap" from "failed to read" either way, so treating 0
-    // as an error would misreport a common, valid configuration.
+    // 0 is legitimate here -- unlike memory, plenty of real hosts run with
+    // no swap at all, and sysinfo can't tell "no swap" from "failed to
+    // read" either way. Erroring on it would misreport a common, valid setup.
     lua.push_number(INFO.total_swap as f64);
     1
 }

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -19,9 +19,8 @@ function sysinfo.get_core_count() end
 --- @return number
 function sysinfo.get_memory() end
 
---- Returns total swap space, in bytes.
---- Raises a Lua error if the swap size could not be read (including on
---- systems with no swap configured).
+--- Returns total swap space, in bytes. Returns 0 (never raises) if the host
+--- has no swap configured.
 --- @return number
 function sysinfo.get_swap() end
 


### PR DESCRIPTION
sysinfo can't distinguish "no swap configured" from "failed to read
swap" -- both come back as a bare 0. The old behaviour treated that 0
as a read failure and raised. That's wrong for the common case (a lot
of real hosts, especially containers and VPSes, run with no swap at
all) and right only for the rare one.

get_swap() now always succeeds and returns 0 in that case.

BREAKING CHANGE: sysinfo.get_swap() no longer raises a Lua error when
the host has no swap configured. Callers that pcall-wrapped it
expecting that error path will silently stop hitting it and just see
a 0 return instead.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>