### PR TITLE
feat: add sysinfo.get_used_swap() and sysinfo.get_free_swap()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ An [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file is
 
 ## Semantics
 
-- Every value except `get_version()` and `get_build_info()` is **snapshotted once**, when the module loads, not re-read on each call — cheap to call repeatedly, but won't reflect a mid-session change (e.g. hot-added swap).
+- Values fall into two groups:
+  - **Static** — facts that don't change while the server runs (total memory, total swap, core count, OS/kernel version, hostname). Captured once, when the module loads, and never re-read.
+  - **Live** — values that do change (currently: used/free swap). Read fresh from the OS each call, though the underlying refresh is throttled internally to avoid hammering it on back-to-back calls, so a value may lag by a fraction of a second under heavy polling.
+
+  Each function's entry below says which group it's in.
 - Most getters **raise a Lua error** (rather than returning `nil`) if their value couldn't be read at all. A handful return `0` instead where zero is itself a legitimate answer rather than a failure signal — `get_swap()` on a swapless host being the common case — see each function's entry in the API reference below for which rule applies. If you're calling something platform-specific that might not apply to the host you're on, wrap it in `pcall`:
 
   ```lua
@@ -60,35 +64,41 @@ An [LuaLS](https://github.com/LuaLS/lua-language-server) type definition file is
 ## API Reference
 
 ### `sysinfo.get_core_count(): int`
-Returns the number of physical cores (not threads) on a system.
-  
+**Static.** Returns the number of physical cores (not threads) on a system.
+
 ### `sysinfo.get_memory(): number`
-Returns total system memory, in bytes.
+**Static.** Returns total system memory, in bytes.
 
 ```lua
 local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ```
 
 ### `sysinfo.get_swap(): number`
-Returns total swap space, in bytes. Returns `0` (never raises) if the host has no swap configured — that's a legitimate, common state, not a read failure.
-  
+**Static.** Returns total swap space, in bytes. Returns `0` (never raises) if the host has no swap configured — that's a legitimate, common state, not a read failure.
+
+### `sysinfo.get_used_swap(): number`
+**Live.** Returns swap currently in use, in bytes. Never raises.
+
+### `sysinfo.get_free_swap(): number`
+**Live.** Returns unused swap space, in bytes. Never raises.
+
 ### `sysinfo.get_system_name(): string`
-Returns the system name.
-  
+**Static.** Returns the system name.
+
 ### `sysinfo.get_host_name(): string`
-Returns the system DNS name.
-  
+**Static.** Returns the system DNS name.
+
 ### `sysinfo.get_system_long_version(): string`
-Returns the system version long name.
-  
+**Static.** Returns the system version long name.
+
 ### `sysinfo.get_system_version(): string`
-Returns the system version name.
-  
+**Static.** Returns the system version name.
+
 ### `sysinfo.get_kernel_version(): string`
-Returns the kernel version name.
+**Static.** Returns the kernel version name.
 
 ### `sysinfo.get_version(): string`
-Returns the module's own version, e.g. `"2.0.0"`.
+Returns the module's own version, e.g. `"2.0.0"`. Always live, but the version can't change without a restart, so the distinction is moot here.
 
 ### `sysinfo.get_build_info(): table`
 Returns build information for the running binary:

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -45,8 +45,8 @@ return {
 
                 expect( used ).to.beA( "number" )
                 expect( free ).to.beA( "number" )
-                expect( used ).to.beGreaterThan( -1 )
-                expect( free ).to.beGreaterThan( -1 )
+                expect( used ).toNot.beLessThan( 0 )
+                expect( free ).toNot.beLessThan( 0 )
 
                 -- Three separate reads, not one atomic snapshot -- allow a
                 -- little drift rather than requiring an exact match.

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -43,15 +43,15 @@ return {
                 local used = sysinfo.get_used_swap()
                 local free = sysinfo.get_free_swap()
 
-                expect( used ).to.beA( "number" )
-                expect( free ).to.beA( "number" )
-                expect( used ).toNot.beLessThan( 0 )
-                expect( free ).toNot.beLessThan( 0 )
+                expect(used).to.beA("number")
+                expect(free).to.beA("number")
+                expect(used).toNot.beLessThan(0)
+                expect(free).toNot.beLessThan(0)
 
                 -- Three separate reads, not one atomic snapshot -- allow a
                 -- little drift rather than requiring an exact match.
-                local drift = math.abs( ( used + free ) - total )
-                expect( drift ).to.beLessThan( math.max( total * 0.05, 1 ) )
+                local drift = math.abs((used + free) - total)
+                expect(drift).to.beLessThan(math.max(total * 0.05, 1))
             end
         },
         {

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -37,6 +37,24 @@ return {
             end
         },
         {
+            name = "Reports used/free swap as non-negative bytes that add up to about the total, never raising",
+            func = function()
+                local total = sysinfo.get_swap()
+                local used = sysinfo.get_used_swap()
+                local free = sysinfo.get_free_swap()
+
+                expect( used ).to.beA( "number" )
+                expect( free ).to.beA( "number" )
+                expect( used ).to.beGreaterThan( -1 )
+                expect( free ).to.beGreaterThan( -1 )
+
+                -- Three separate reads, not one atomic snapshot -- allow a
+                -- little drift rather than requiring an exact match.
+                local drift = math.abs( ( used + free ) - total )
+                expect( drift ).to.beLessThan( math.max( total * 0.05, 1 ) )
+            end
+        },
+        {
             name = "Identity getters return a non-empty string, or raise when unavailable",
             func = function()
                 -- Minimal containers may lack e.g. /etc/os-release, in which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ static CACHE: LazyLock<Mutex<Cache>> = LazyLock::new(|| {
     })
 });
 
-#[allow(dead_code)] // consumed starting with the swap-used-free layer
 fn with_memory<T>(f: impl FnOnce(&System) -> T) -> T {
     let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
     if cache
@@ -126,6 +125,18 @@ unsafe fn get_memory(lua: State) -> i32 {
 unsafe fn get_swap(lua: State) -> i32 {
     // 0 is legitimate -- sysinfo can't tell "no swap" from "failed to read".
     lua.push_number(INFO.total_swap as f64);
+    1
+}
+
+#[lua_function]
+unsafe fn get_used_swap(lua: State) -> i32 {
+    with_memory(|sys| lua.push_number(sys.used_swap() as f64));
+    1
+}
+
+#[lua_function]
+unsafe fn get_free_swap(lua: State) -> i32 {
+    with_memory(|sys| lua.push_number(sys.free_swap() as f64));
     1
 }
 
@@ -245,10 +256,12 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 10);
+    lua.create_table(0, 12);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
+    export_lua_function!(get_used_swap);
+    export_lua_function!(get_free_swap);
     export_lua_function!(get_system_name);
     export_lua_function!(get_system_long_version);
     export_lua_function!(get_system_version);

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -24,6 +24,16 @@ function sysinfo.get_memory() end
 --- @return number
 function sysinfo.get_swap() end
 
+--- Returns swap currently in use, in bytes. Never raises. Live -- read fresh
+--- from the OS each call (internally throttled).
+--- @return number
+function sysinfo.get_used_swap() end
+
+--- Returns unused swap space, in bytes. Never raises. Live -- read fresh
+--- from the OS each call (internally throttled).
+--- @return number
+function sysinfo.get_free_swap() end
+
 --- Returns the system name.
 --- Raises a Lua error if the system name could not be read.
 --- @return string


### PR DESCRIPTION
Both live -- read through the throttled cache added in the base
layer, refreshed on demand rather than snapshotted once. Same
no-error semantics as get_swap(): sysinfo can't signal "failed to
read" separately from "legitimately zero", so neither getter raises.

README's Semantics section now documents the Static/Live split
explicitly, and each API entry is tagged with which one it is.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>