### PR TITLE
feat: add sysinfo.get_used_memory(), get_free_memory(), get_available_memory()

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ### `sysinfo.get_free_swap(): number`
 **Live.** Returns unused swap space, in bytes. Never raises.
 
+### `sysinfo.get_used_memory(): number`
+**Live.** Returns memory currently in use, in bytes. Never raises.
+
+### `sysinfo.get_free_memory(): number`
+**Live.** Returns memory not used for anything, in bytes. Never raises. On Linux this is usually much lower than you'd expect — see `get_available_memory()`.
+
+### `sysinfo.get_available_memory(): number`
+**Live.** Returns memory available for new allocations without swapping, in bytes. Never raises. This is the number you almost always want over `get_free_memory()`: on Linux, "free" excludes memory the kernel is using for reclaimable disk cache, which in practice is available on demand. "Available" accounts for that.
+
 ### `sysinfo.get_system_name(): string`
 **Static.** Returns the system name.
 

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -55,6 +55,25 @@ return {
             end
         },
         {
+            name = "Reports used/free/available memory as positive bytes, never raising, consistent with total",
+            func = function()
+                local total = sysinfo.get_memory()
+                local used = sysinfo.get_used_memory()
+                local free = sysinfo.get_free_memory()
+                local available = sysinfo.get_available_memory()
+
+                for _, value in ipairs( { used, free, available } ) do
+                    expect( value ).to.beA( "number" )
+                    expect( value ).to.beGreaterThan( 0 )
+                    expect( value ).to.beLessThan( total )
+                end
+
+                -- available accounts for reclaimable cache that free doesn't,
+                -- so it should never be smaller.
+                expect( available ).to.beGreaterThan( free - 1 )
+            end
+        },
+        {
             name = "Identity getters return a non-empty string, or raise when unavailable",
             func = function()
                 -- Minimal containers may lack e.g. /etc/os-release, in which

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -62,15 +62,15 @@ return {
                 local free = sysinfo.get_free_memory()
                 local available = sysinfo.get_available_memory()
 
-                for _, value in ipairs( { used, free, available } ) do
-                    expect( value ).to.beA( "number" )
-                    expect( value ).to.beGreaterThan( 0 )
-                    expect( value ).to.beLessThan( total )
+                for _, value in ipairs({ used, free, available }) do
+                    expect(value).to.beA("number")
+                    expect(value).to.beGreaterThan(0)
+                    expect(value).to.beLessThan(total)
                 end
 
                 -- available accounts for reclaimable cache that free doesn't,
                 -- so it should never be smaller.
-                expect( available ).to.beGreaterThan( free - 1 )
+                expect(available).to.beGreaterThan(free - 1)
             end
         },
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,24 @@ unsafe fn get_free_swap(lua: State) -> i32 {
 }
 
 #[lua_function]
+unsafe fn get_used_memory(lua: State) -> i32 {
+    with_memory(|sys| lua.push_number(sys.used_memory() as f64));
+    1
+}
+
+#[lua_function]
+unsafe fn get_free_memory(lua: State) -> i32 {
+    with_memory(|sys| lua.push_number(sys.free_memory() as f64));
+    1
+}
+
+#[lua_function]
+unsafe fn get_available_memory(lua: State) -> i32 {
+    with_memory(|sys| lua.push_number(sys.available_memory() as f64));
+    1
+}
+
+#[lua_function]
 unsafe fn get_system_name(lua: State) -> i32 {
     if INFO.name.is_empty() {
         error(lua, err!("read the system name"));
@@ -256,12 +274,15 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 12);
+    lua.create_table(0, 15);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
     export_lua_function!(get_used_swap);
     export_lua_function!(get_free_swap);
+    export_lua_function!(get_used_memory);
+    export_lua_function!(get_free_memory);
+    export_lua_function!(get_available_memory);
     export_lua_function!(get_system_name);
     export_lua_function!(get_system_long_version);
     export_lua_function!(get_system_version);

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -34,6 +34,23 @@ function sysinfo.get_used_swap() end
 --- @return number
 function sysinfo.get_free_swap() end
 
+--- Returns memory currently in use, in bytes. Never raises. Live -- read
+--- fresh from the OS each call (internally throttled).
+--- @return number
+function sysinfo.get_used_memory() end
+
+--- Returns memory not used for anything, in bytes. Never raises. On Linux,
+--- prefer get_available_memory() -- this excludes reclaimable disk cache.
+--- Live -- read fresh from the OS each call (internally throttled).
+--- @return number
+function sysinfo.get_free_memory() end
+
+--- Returns memory available for new allocations without swapping, in bytes.
+--- Never raises. Live -- read fresh from the OS each call (internally
+--- throttled).
+--- @return number
+function sysinfo.get_available_memory() end
+
 --- Returns the system name.
 --- Raises a Lua error if the system name could not be read.
 --- @return string


### PR DESCRIPTION
Same live/no-error treatment as the swap getters, through the same
throttled cache. README explains the free-vs-available distinction
explicitly (the classic Linux gotcha: free excludes reclaimable disk
cache, available doesn't) since get_available_memory() is the one
callers almost always actually want.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>