### PR TITLE
feat: add sysinfo.get_uptime() and sysinfo.get_boot_time()

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ### `sysinfo.get_available_memory(): number`
 **Live.** Returns memory available for new allocations without swapping, in bytes. Never raises. This is the number you almost always want over `get_free_memory()`: on Linux, "free" excludes memory the kernel is using for reclaimable disk cache, which in practice is available on demand. "Available" accounts for that.
 
+### `sysinfo.get_uptime(): number`
+**Live.** Returns seconds since the host booted. Never raises.
+
+### `sysinfo.get_boot_time(): number`
+**Live** in the sense that it's read fresh each call, but the value itself is fixed for the life of the boot — a Unix timestamp (seconds since epoch). Never raises.
+
 ### `sysinfo.get_system_name(): string`
 **Static.** Returns the system name.
 

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -81,7 +81,7 @@ return {
 
                 expect( uptime ).to.beA( "number" )
                 expect( boot_time ).to.beA( "number" )
-                expect( uptime ).to.beGreaterThan( -1 )
+                expect( uptime ).toNot.beLessThan( 0 )
 
                 -- CI runners don't predate the epoch.
                 expect( boot_time ).to.beGreaterThan( 0 )

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -74,6 +74,20 @@ return {
             end
         },
         {
+            name = "Reports uptime and boot time consistently, never raising",
+            func = function()
+                local uptime = sysinfo.get_uptime()
+                local boot_time = sysinfo.get_boot_time()
+
+                expect( uptime ).to.beA( "number" )
+                expect( boot_time ).to.beA( "number" )
+                expect( uptime ).to.beGreaterThan( -1 )
+
+                -- CI runners don't predate the epoch.
+                expect( boot_time ).to.beGreaterThan( 0 )
+            end
+        },
+        {
             name = "Identity getters return a non-empty string, or raise when unavailable",
             func = function()
                 -- Minimal containers may lack e.g. /etc/os-release, in which

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -79,12 +79,12 @@ return {
                 local uptime = sysinfo.get_uptime()
                 local boot_time = sysinfo.get_boot_time()
 
-                expect( uptime ).to.beA( "number" )
-                expect( boot_time ).to.beA( "number" )
-                expect( uptime ).toNot.beLessThan( 0 )
+                expect(uptime).to.beA("number")
+                expect(boot_time).to.beA("number")
+                expect(uptime).toNot.beLessThan(0)
 
                 -- CI runners don't predate the epoch.
-                expect( boot_time ).to.beGreaterThan( 0 )
+                expect(boot_time).to.beGreaterThan(0)
             end
         },
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,18 @@ unsafe fn get_available_memory(lua: State) -> i32 {
 }
 
 #[lua_function]
+unsafe fn get_uptime(lua: State) -> i32 {
+    lua.push_number(System::uptime() as f64);
+    1
+}
+
+#[lua_function]
+unsafe fn get_boot_time(lua: State) -> i32 {
+    lua.push_number(System::boot_time() as f64);
+    1
+}
+
+#[lua_function]
 unsafe fn get_system_name(lua: State) -> i32 {
     if INFO.name.is_empty() {
         error(lua, err!("read the system name"));
@@ -274,7 +286,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 15);
+    lua.create_table(0, 17);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
@@ -283,6 +295,8 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     export_lua_function!(get_used_memory);
     export_lua_function!(get_free_memory);
     export_lua_function!(get_available_memory);
+    export_lua_function!(get_uptime);
+    export_lua_function!(get_boot_time);
     export_lua_function!(get_system_name);
     export_lua_function!(get_system_long_version);
     export_lua_function!(get_system_version);

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -51,6 +51,16 @@ function sysinfo.get_free_memory() end
 --- @return number
 function sysinfo.get_available_memory() end
 
+--- Returns seconds since the host booted. Never raises. Live -- read fresh
+--- from the OS each call.
+--- @return number
+function sysinfo.get_uptime() end
+
+--- Returns the host's boot time as a Unix timestamp (seconds since epoch).
+--- Never raises. Fixed for the life of the boot, but read fresh each call.
+--- @return number
+function sysinfo.get_boot_time() end
+
 --- Returns the system name.
 --- Raises a Lua error if the system name could not be read.
 --- @return string


### PR DESCRIPTION
Both are plain pass-throughs to System::uptime()/boot_time() -- these
are associated functions in sysinfo, not tied to a System instance, so
they need no cache and can't meaningfully fail.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>