### PR TITLE
feat: add sysinfo.get_cpu_usage(), get_cpu_arch(), get_distro_id(), get_distro_id_like()

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ### `sysinfo.get_boot_time(): number`
 **Live** in the sense that it's read fresh each call, but the value itself is fixed for the life of the boot — a Unix timestamp (seconds since epoch). Never raises.
 
+### `sysinfo.get_cpu_usage(): number`
+**Live.** Returns global CPU usage as a percentage (`0`–`100`, roughly — see below). Never raises. CPU usage is computed by diffing against the previous reading, so **the very first call after the module loads is unreliable** (sysinfo's own docs: "very likely inaccurate" — not necessarily `0`, it can read as the platform maximum instead); every call after that reflects usage since the last internal refresh (throttled the same way memory is — see [Semantics](#semantics)).
+
+### `sysinfo.get_cpu_arch(): string`
+**Static.** Returns the CPU architecture (e.g. `"x86_64"`). Never raises.
+
+### `sysinfo.get_distro_id(): string`
+**Static.** Despite the name, not Linux-specific: on Linux it's the distribution id (e.g. `"ubuntu"`); elsewhere it falls back to a normalized platform name (`"windows"`, `"macos"`). Never raises.
+
+### `sysinfo.get_distro_id_like(): table`
+**Static.** Returns an array of the distribution's closest relatives (e.g. `{"debian"}` for Ubuntu), as reported by the OS. Never raises — an empty table (`{}`) is the normal answer on most non-Linux platforms and plenty of Linux distributions too (Arch, for instance, declares none).
+
 ### `sysinfo.get_system_name(): string`
 **Static.** Returns the system name.
 

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -92,7 +92,7 @@ return {
             func = function()
                 local usage = sysinfo.get_cpu_usage()
                 expect( usage ).to.beA( "number" )
-                expect( usage ).to.beGreaterThan( -1 )
+                expect( usage ).toNot.beLessThan( 0 )
                 expect( usage ).to.beLessThan( 100 * sysinfo.get_core_count() + 1 )
             end
         },

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -88,6 +88,23 @@ return {
             end
         },
         {
+            name = "Reports CPU usage as a number in a sane range, never raising",
+            func = function()
+                local usage = sysinfo.get_cpu_usage()
+                expect( usage ).to.beA( "number" )
+                expect( usage ).to.beGreaterThan( -1 )
+                expect( usage ).to.beLessThan( 100 * sysinfo.get_core_count() + 1 )
+            end
+        },
+        {
+            name = "Reports CPU architecture as a non-empty string, never raising",
+            func = function()
+                local arch = sysinfo.get_cpu_arch()
+                expect( arch ).to.beA( "string" )
+                expect( #arch ).to.beGreaterThan( 0 )
+            end
+        },
+        {
             name = "Identity getters return a non-empty string, or raise when unavailable",
             func = function()
                 -- Minimal containers may lack e.g. /etc/os-release, in which
@@ -106,6 +123,28 @@ return {
                         expect( value ).to.beA( "string" )
                         expect( #value ).to.beGreaterThan( 0 )
                     end
+                end
+            end
+        },
+        {
+            name = "Reports distro id as a non-empty string, never raising",
+            func = function()
+                -- CI runs on Linux, so this should be a real distro id --
+                -- but the contract holds on any platform.
+                local id = sysinfo.get_distro_id()
+                expect( id ).to.beA( "string" )
+                expect( #id ).to.beGreaterThan( 0 )
+            end
+        },
+        {
+            name = "Reports distro id-like as a table of strings, never raising",
+            func = function()
+                local relatives = sysinfo.get_distro_id_like()
+                expect( relatives ).to.beA( "table" )
+
+                for _, relative in ipairs( relatives ) do
+                    expect( relative ).to.beA( "string" )
+                    expect( #relative ).to.beGreaterThan( 0 )
                 end
             end
         },

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -91,17 +91,17 @@ return {
             name = "Reports CPU usage as a number in a sane range, never raising",
             func = function()
                 local usage = sysinfo.get_cpu_usage()
-                expect( usage ).to.beA( "number" )
-                expect( usage ).toNot.beLessThan( 0 )
-                expect( usage ).to.beLessThan( 100 * sysinfo.get_core_count() + 1 )
+                expect(usage).to.beA("number")
+                expect(usage).toNot.beLessThan(0)
+                expect(usage).to.beLessThan(100 * sysinfo.get_core_count() + 1)
             end
         },
         {
             name = "Reports CPU architecture as a non-empty string, never raising",
             func = function()
                 local arch = sysinfo.get_cpu_arch()
-                expect( arch ).to.beA( "string" )
-                expect( #arch ).to.beGreaterThan( 0 )
+                expect(arch).to.beA("string")
+                expect(#arch).to.beGreaterThan(0)
             end
         },
         {
@@ -132,19 +132,19 @@ return {
                 -- CI runs on Linux, so this should be a real distro id --
                 -- but the contract holds on any platform.
                 local id = sysinfo.get_distro_id()
-                expect( id ).to.beA( "string" )
-                expect( #id ).to.beGreaterThan( 0 )
+                expect(id).to.beA("string")
+                expect(#id).to.beGreaterThan(0)
             end
         },
         {
             name = "Reports distro id-like as a table of strings, never raising",
             func = function()
                 local relatives = sysinfo.get_distro_id_like()
-                expect( relatives ).to.beA( "table" )
+                expect(relatives).to.beA("table")
 
-                for _, relative in ipairs( relatives ) do
-                    expect( relative ).to.beA( "string" )
-                    expect( #relative ).to.beGreaterThan( 0 )
+                for _, relative in ipairs(relatives) do
+                    expect(relative).to.beA("string")
+                    expect(#relative).to.beGreaterThan(0)
                 end
             end
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@ fn with_memory<T>(f: impl FnOnce(&System) -> T) -> T {
     f(&cache.system)
 }
 
-#[allow(dead_code)] // consumed starting with the cpu-and-distro layer
 fn with_cpu<T>(f: impl FnOnce(&System) -> T) -> T {
     let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
     if cache
@@ -167,6 +166,43 @@ unsafe fn get_uptime(lua: State) -> i32 {
 #[lua_function]
 unsafe fn get_boot_time(lua: State) -> i32 {
     lua.push_number(System::boot_time() as f64);
+    1
+}
+
+#[lua_function]
+unsafe fn get_cpu_usage(lua: State) -> i32 {
+    with_cpu(|sys| lua.push_number(sys.global_cpu_usage() as f64));
+    1
+}
+
+#[lua_function]
+unsafe fn get_cpu_arch(lua: State) -> i32 {
+    // Always populated: sysinfo falls back to the build's target arch if the
+    // OS query fails.
+    lua.push_string(&System::cpu_arch());
+    1
+}
+
+#[lua_function]
+unsafe fn get_distro_id(lua: State) -> i32 {
+    // Despite the name, not Linux-specific -- sysinfo falls back to
+    // std::env::consts::OS ("windows", "macos", ...) everywhere else, so
+    // this is always populated too.
+    lua.push_string(&System::distribution_id());
+    1
+}
+
+#[lua_function]
+unsafe fn get_distro_id_like(lua: State) -> i32 {
+    // A plain array of strings, commonly empty -- that's not a failure, most
+    // platforms (and plenty of Linux distros, e.g. Arch) just don't have any
+    // declared relatives.
+    let ids = System::distribution_id_like();
+    lua.create_table(ids.len() as i32, 0);
+    for (i, id) in ids.iter().enumerate() {
+        lua.push_string(id);
+        lua.raw_seti(-2, (i + 1) as i32);
+    }
     1
 }
 
@@ -286,7 +322,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 17);
+    lua.create_table(0, 21);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
@@ -297,6 +333,10 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     export_lua_function!(get_available_memory);
     export_lua_function!(get_uptime);
     export_lua_function!(get_boot_time);
+    export_lua_function!(get_cpu_usage);
+    export_lua_function!(get_cpu_arch);
+    export_lua_function!(get_distro_id);
+    export_lua_function!(get_distro_id_like);
     export_lua_function!(get_system_name);
     export_lua_function!(get_system_long_version);
     export_lua_function!(get_system_version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,8 @@ unsafe fn get_distro_id(lua: State) -> i32 {
 
 #[lua_function]
 unsafe fn get_distro_id_like(lua: State) -> i32 {
-    // A plain array of strings, commonly empty -- that's not a failure, most
-    // platforms (and plenty of Linux distros, e.g. Arch) just don't have any
-    // declared relatives.
+    // Commonly empty -- that's not a failure, most platforms (and plenty of
+    // Linux distros, e.g. Arch) just don't have any declared relatives.
     let ids = System::distribution_id_like();
     lua.create_table(ids.len() as i32, 0);
     for (i, id) in ids.iter().enumerate() {

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -61,6 +61,29 @@ function sysinfo.get_uptime() end
 --- @return number
 function sysinfo.get_boot_time() end
 
+--- Returns global CPU usage as a percentage (0-100, roughly). Never raises.
+--- Computed by diffing against the previous reading, so the first call after
+--- the module loads is unreliable (not necessarily 0) -- every call after
+--- that is meaningful.
+--- @return number
+function sysinfo.get_cpu_usage() end
+
+--- Returns the CPU architecture, e.g. "x86_64". Never raises.
+--- @return string
+function sysinfo.get_cpu_arch() end
+
+--- Despite the name, not Linux-specific: on Linux this is the distribution
+--- id (e.g. "ubuntu"); elsewhere it falls back to a normalized platform name
+--- ("windows", "macos"). Never raises.
+--- @return string
+function sysinfo.get_distro_id() end
+
+--- Returns an array of the distribution's closest relatives (e.g. {"debian"}
+--- for Ubuntu). Never raises -- an empty table is the normal answer on most
+--- non-Linux platforms and plenty of Linux distributions too.
+--- @return string[]
+function sysinfo.get_distro_id_like() end
+
 --- Returns the system name.
 --- Raises a Lua error if the system name could not be read.
 --- @return string


### PR DESCRIPTION
get_cpu_usage() is live, through the throttled cache -- like all
diff-based CPU readings, the first call after module load is
unreliable (sysinfo's own words: "very likely inaccurate", not
necessarily 0).

get_cpu_arch()/get_distro_id()/get_distro_id_like() turned out not to
need the cache or an error path at all once I checked sysinfo's actual
source rather than trusting scraped docs: cpu_arch() and
distribution_id() both fall back to std::env::consts, so they're
always populated on every platform (distribution_id() isn't
Linux-specific despite the name -- it returns "windows"/"macos"
elsewhere). distribution_id_like() returns Vec<String>, not a single
string, so it's exposed as a Lua array table rather than forced into a
scalar; an empty table is the normal answer on most platforms.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>