### PR TITLE
feat: add sysinfo.get_load_average()

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ### `sysinfo.get_distro_id_like(): table`
 **Static.** Returns an array of the distribution's closest relatives (e.g. `{"debian"}` for Ubuntu), as reported by the OS. Never raises — an empty table (`{}`) is the normal answer on most non-Linux platforms and plenty of Linux distributions too (Arch, for instance, declares none).
 
+### `sysinfo.get_load_average(): table`
+**Live.** Returns `{one, five, fifteen}` — the standard 1/5/15-minute load average, as plain numbers. Never raises.
+
+This is a genuine load average on every platform this module ships for, including Windows: sysinfo doesn't approximate it from CPU usage there, it samples a real Windows performance counter (`Processor Queue Length`) every 5 seconds in the background and folds it into the exact same exponential-moving-average formula the Linux kernel uses. It is **not** the same metric as `get_cpu_usage()` — load average reflects queue depth (processes wanting to run, including ones blocked on I/O), not a CPU-busy percentage, and a value above your core count is a normal, meaningful signal (unlike CPU usage, which caps out around 100% per core).
+
+Like `get_cpu_usage()`, the very first reads after module load (or after a fresh boot) will be near-zero — this is a genuine moving average that needs time to ramp up, not a bug or a platform gap.
+
 ### `sysinfo.get_system_name(): string`
 **Static.** Returns the system name.
 

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -144,7 +144,7 @@ return {
 
                 for _, key in ipairs( { "one", "five", "fifteen" } ) do
                     expect( avg[key] ).to.beA( "number" )
-                    expect( avg[key] ).to.beGreaterThan( -1 )
+                    expect( avg[key] ).toNot.beLessThan( 0 )
                 end
             end
         },

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -140,11 +140,11 @@ return {
             name = "Reports load average as a table of three non-negative numbers, never raising",
             func = function()
                 local avg = sysinfo.get_load_average()
-                expect( avg ).to.exist()
+                expect(avg).to.exist()
 
-                for _, key in ipairs( { "one", "five", "fifteen" } ) do
-                    expect( avg[key] ).to.beA( "number" )
-                    expect( avg[key] ).toNot.beLessThan( 0 )
+                for _, key in ipairs({ "one", "five", "fifteen" }) do
+                    expect(avg[key]).to.beA("number")
+                    expect(avg[key]).toNot.beLessThan(0)
                 end
             end
         },

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -137,6 +137,18 @@ return {
             end
         },
         {
+            name = "Reports load average as a table of three non-negative numbers, never raising",
+            func = function()
+                local avg = sysinfo.get_load_average()
+                expect( avg ).to.exist()
+
+                for _, key in ipairs( { "one", "five", "fifteen" } ) do
+                    expect( avg[key] ).to.beA( "number" )
+                    expect( avg[key] ).to.beGreaterThan( -1 )
+                end
+            end
+        },
+        {
             name = "Reports distro id-like as a table of strings, never raising",
             func = function()
                 local relatives = sysinfo.get_distro_id_like()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,19 @@ unsafe fn get_distro_id(lua: State) -> i32 {
 }
 
 #[lua_function]
+unsafe fn get_load_average(lua: State) -> i32 {
+    let avg = System::load_average();
+    lua.create_table(0, 3);
+    lua.push_number(avg.one);
+    lua.set_field(-2, lua_string!("one"));
+    lua.push_number(avg.five);
+    lua.set_field(-2, lua_string!("five"));
+    lua.push_number(avg.fifteen);
+    lua.set_field(-2, lua_string!("fifteen"));
+    1
+}
+
+#[lua_function]
 unsafe fn get_distro_id_like(lua: State) -> i32 {
     // Commonly empty -- that's not a failure, most platforms (and plenty of
     // Linux distros, e.g. Arch) just don't have any declared relatives.
@@ -321,7 +334,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 21);
+    lua.create_table(0, 22);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
@@ -336,6 +349,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     export_lua_function!(get_cpu_arch);
     export_lua_function!(get_distro_id);
     export_lua_function!(get_distro_id_like);
+    export_lua_function!(get_load_average);
     export_lua_function!(get_system_name);
     export_lua_function!(get_system_long_version);
     export_lua_function!(get_system_version);

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -84,6 +84,21 @@ function sysinfo.get_distro_id() end
 --- @return string[]
 function sysinfo.get_distro_id_like() end
 
+--- @class SysinfoLoadAverage
+--- @field one number
+--- @field five number
+--- @field fifteen number
+
+--- Returns the standard 1/5/15-minute load average. Never raises. A genuine
+--- load average on every platform (including Windows -- sysinfo samples a
+--- real performance counter there, it doesn't approximate from CPU usage).
+--- Not the same metric as get_cpu_usage() -- this reflects queue depth, not
+--- a CPU-busy percentage, so values above the core count are normal. The
+--- first reads after module load (or a fresh boot) are near-zero; that's the
+--- moving average ramping up, not a bug.
+--- @return SysinfoLoadAverage
+function sysinfo.get_load_average() end
+
 --- Returns the system name.
 --- Raises a Lua error if the system name could not be read.
 --- @return string


### PR DESCRIPTION
Returns {one, five, fifteen} as plain numbers. An associated function
in sysinfo, so no cache needed, and it can't meaningfully fail.

No CPU-usage-based polyfill needed on Windows -- checked the actual
pinned source (src/windows/cpu.rs) rather than assume: sysinfo already
samples a real "Processor Queue Length" performance counter there
every 5 seconds via a background callback, folding it into the exact
same exponential-moving-average formula the Linux kernel uses. A
CPU-usage-derived approximation would have been a strictly worse
substitute for what's already there for free, and would have
conflated two genuinely different metrics (queue depth vs CPU-busy
percentage). README documents this plus the natural cold-start
ramp-up, which applies to a fresh boot on every platform, not just
Windows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>