### PR TITLE
feat: add throttled refresh infrastructure for dynamic metrics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,9 @@ unsafe fn error<S: AsRef<str>>(lua: State, err: S) -> ! {
     lua.error(err)
 }
 
-/// Refreshed on demand rather than snapshotted once, and throttled per kind
-/// -- a single shared timestamp would let one kind's refresh silently starve
-/// the other. sysinfo recommends not refreshing CPU data faster than
-/// `MINIMUM_CPU_UPDATE_INTERVAL`; memory doesn't need polling any harder
-/// than that either.
+/// Throttled per kind, to allow others to refresh. The minimum sysinfo
+/// upstream recommended polling rate is `MINIMUM_CPU_UPDATE_INTERVAL`,
+/// reused here for memory too.
 struct Cache {
     system: System,
     last_memory_refresh: Option<Instant>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,10 @@ unsafe fn error<S: AsRef<str>>(lua: State, err: S) -> ! {
     lua.error(err)
 }
 
-/// Values that can change while the server runs (memory pressure, CPU load),
-/// unlike `Snapshot`'s facts. Refreshed on demand and throttled per kind --
-/// sysinfo recommends not refreshing CPU data faster than
-/// `MINIMUM_CPU_UPDATE_INTERVAL`, and memory doesn't need polling any harder
+/// Refreshed on demand rather than snapshotted once, and throttled per kind
+/// -- a single shared timestamp would let one kind's refresh silently starve
+/// the other. sysinfo recommends not refreshing CPU data faster than
+/// `MINIMUM_CPU_UPDATE_INTERVAL`; memory doesn't need polling any harder
 /// than that either.
 struct Cache {
     system: System,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
+use std::time::Instant;
 
 use gmod::lua::{LuaString, State};
 use gmod::{gmod13_close, gmod13_open, lua_function, lua_string};
-use sysinfo::{MemoryRefreshKind, RefreshKind, System};
+use sysinfo::{
+    CpuRefreshKind, MemoryRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL,
+};
 
 mod build_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -50,6 +53,55 @@ static INFO: LazyLock<Snapshot> = LazyLock::new(|| {
 
 unsafe fn error<S: AsRef<str>>(lua: State, err: S) -> ! {
     lua.error(err)
+}
+
+/// Values that can change while the server runs (memory pressure, CPU load),
+/// unlike `Snapshot`'s facts. Refreshed on demand and throttled per kind --
+/// sysinfo recommends not refreshing CPU data faster than
+/// `MINIMUM_CPU_UPDATE_INTERVAL`, and memory doesn't need polling any harder
+/// than that either.
+struct Cache {
+    system: System,
+    last_memory_refresh: Option<Instant>,
+    last_cpu_refresh: Option<Instant>,
+}
+
+static CACHE: LazyLock<Mutex<Cache>> = LazyLock::new(|| {
+    Mutex::new(Cache {
+        system: System::new(),
+        last_memory_refresh: None,
+        last_cpu_refresh: None,
+    })
+});
+
+#[allow(dead_code)] // consumed starting with the swap-used-free layer
+fn with_memory<T>(f: impl FnOnce(&System) -> T) -> T {
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if cache
+        .last_memory_refresh
+        .is_none_or(|t| t.elapsed() >= MINIMUM_CPU_UPDATE_INTERVAL)
+    {
+        cache
+            .system
+            .refresh_memory_specifics(MemoryRefreshKind::everything());
+        cache.last_memory_refresh = Some(Instant::now());
+    }
+    f(&cache.system)
+}
+
+#[allow(dead_code)] // consumed starting with the cpu-and-distro layer
+fn with_cpu<T>(f: impl FnOnce(&System) -> T) -> T {
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if cache
+        .last_cpu_refresh
+        .is_none_or(|t| t.elapsed() >= MINIMUM_CPU_UPDATE_INTERVAL)
+    {
+        cache
+            .system
+            .refresh_cpu_specifics(CpuRefreshKind::nothing().with_cpu_usage());
+        cache.last_cpu_refresh = Some(Instant::now());
+    }
+    f(&cache.system)
 }
 
 #[lua_function]


### PR DESCRIPTION
Base layer of a 7-PR stack adding dynamic (non-static) system metrics from `sysinfo`. This one is pure infrastructure -- no new Lua-visible functions yet.

## What it adds

The existing `Snapshot`/`INFO` pattern (`src/lib.rs`) captures facts once at module load, correct for values that never change (total memory, core count, OS version) but wrong for ones that do (used memory, CPU load). This adds a second static, `Cache`, holding a `Mutex<System>` refreshed on demand instead of once.

`with_memory`/`with_cpu` each throttle their own refresh independently via `sysinfo::MINIMUM_CPU_UPDATE_INTERVAL` -- a single shared throttle timestamp would let one kind's refresh silently starve the other (e.g. a memory read resetting the clock and skipping a CPU refresh that was actually still due).

Both helpers carry `#[allow(dead_code)]` since nothing calls them yet -- removed layer by layer as the next PRs in the stack (#16 onward) add the getters that consume them.

## Verification

`cargo clippy --all-targets --locked -D warnings` clean on both realms, `cargo fmt --check` clean, `cargo build --release` links on both realms.

Stack: this <- #16 <- #17 <- #18 <- #19 <- #20 <- #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
