### PR TITLE
style: drop inter-bracket spacing in the swap test

### DIFF
--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -32,8 +32,8 @@ return {
                 -- than a failure -- unlike the other getters, this must
                 -- never raise.
                 local swap = sysinfo.get_swap()
-                expect( swap ).to.beA( "number" )
-                expect( swap ).toNot.beLessThan( 0 )
+                expect(swap).to.beA("number")
+                expect(swap).toNot.beLessThan(0)
             end
         },
         {


### PR DESCRIPTION
Recovers a fix that got orphaned: it was a follow-up commit on `dynamic/swap-no-error` (PR #16), but #16 merged before this specific commit got pushed, so it never made it into main. Cherry-picked directly onto a fresh branch off `main` rather than rebuilding the closed PR.

Same content as the rest of the current bracket-spacing pass across the stack: `expect( x )` -> `expect(x)`, no other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
