### PR TITLE
fix(ci): make release-plz use git tags, not the crates.io registry

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,3 +7,13 @@ git_release_enable = true
 # so a release is never visible without its assets.
 git_release_draft = true
 changelog_update = true
+
+[[package]]
+name = "gm_sysinfo"
+# Without this, release-plz falls back to checking crates.io for the
+# package's current version. gm_sysinfo has never been published there,
+# so that lookup finds nothing and release-plz silently concludes there's
+# nothing to release -- confirmed by reproducing it locally with the
+# release-plz binary. git_only makes it use git tags instead, which is
+# what git_tag_enable/git_release_enable above already assume.
+git_only = true


### PR DESCRIPTION
Answers "why isn't the release pipeline working" — it's been silently broken since right after v2.0.0 shipped (~03:25 today). Every push to main since then, including the P2 and P3 merges, has produced `release_pr_output: {"prs":[]}` with no error, no release PR, nothing visibly wrong.

## Root cause

`release-plz.toml` sets `[workspace] publish = false`, but that alone doesn't change how release-plz determines the package's *current* version for diffing purposes -- by default it checks the crates.io registry. `gm_sysinfo` has never been published there, so that lookup finds nothing, and release-plz concludes (silently, no error) that there's nothing to release.

## Fix

```toml
[[package]]
name = "gm_sysinfo"
git_only = true
```

Tells release-plz to use git tags as the version source of truth instead, which is what `git_tag_enable`/`git_release_enable` already assumed was happening.

## Verification

Not a guess -- downloaded the actual `release-plz` binary and ran it against real clones of this repo:
- **Without the fix**: reproduced `{"prs":[]}`, matching every CI run since v2.0.0.
- **With the fix**: `gm_sysinfo: 2.0.0 -> 3.0.0` (correctly picking up the `feat:` commits and the breaking `get_swap()` change already merged to main), full changelog generated.

Once this merges, the next push to main should open the release PR that's been missing all day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
