### PR TITLE
fix(ci): remove Cargo.toml publish=false so release-plz can release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ license = "MIT"
 repository = "https://github.com/JoshPiper/gm_sysinfo"
 readme = "README.md"
 keywords = ["garrysmod", "gmod", "binary-module", "sysinfo"]
-publish = false
+# Do not add publish = false here: release-plz's release command filters on
+# this manifest field and would skip the package entirely ("nothing to
+# release"). The crates.io publish opt-out lives in release-plz.toml instead.
 
 [lib]
 name = "gm_sysinfo"


### PR DESCRIPTION
Why #27 merged but v3.0.0 never got tagged or released.

## Root cause

`release-plz release` filters packages through `publishable_packages()` → `is_publishable()`, which reads the **Cargo.toml** `publish` field (traced through release-plz 0.3.160's source: `crates/release_plz_core/src/next_ver.rs`). `publish = false` in the manifest empties the release set before the `git_only` handling from #26 is ever consulted — hence `INFO nothing to release`, exit 0, no tag, no release. The release-plz.toml settings (`publish = false`, `git_only = true`) govern the `release-pr`/`update` code paths, which is why the release PR side worked while `release` silently did nothing.

## Verification

Reproduced both ways with the actual release-plz 0.3.160 binary against real clones of this repo at `b565b7e` (the #27 merge commit):
- **With** manifest `publish = false`: `nothing to release` — byte-for-byte what CI logged.
- **Without** it: `gm_sysinfo 3.0.0: due to dry, skipping the following: ["creation of tag 'v3.0.0'", "creation of git release"]` — i.e. it would have released.

## Trade-off

Manifest `publish = false` also guarded against a stray manual `cargo publish` to crates.io. That guard goes away; the release-plz-level opt-out stays, and a comment in Cargo.toml now explains why the field must remain absent so it doesn't get re-added as innocent-looking hygiene (which is exactly how it got there).

## After merge

The push to main should immediately tag `v3.0.0`, create the draft release, build all 10 binaries, attach them + `SHA256SUMS` + SBOM + `sysinfo.lua`, attest, and undraft — the first end-to-end run of the release asset machinery. I'll verify each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
