### PR TITLE
feat: add sysinfo.get_disks()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ gmcl = ["gmod/gmcl"]
 
 [dependencies]
 gmod = { version = "17", default-features = false }
-sysinfo = { version = "0.39", default-features = false, features = ["system"] }
+sysinfo = { version = "0.39", default-features = false, features = ["system", "disk"] }
 
 [build-dependencies]
 built = { version = "0.8", features = ["chrono", "gix"] }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ This is a genuine load average on every platform this module ships for, includin
 
 Like `get_cpu_usage()`, the very first reads after module load (or after a fresh boot) will be near-zero — this is a genuine moving average that needs time to ramp up, not a bug or a platform gap.
 
+### `sysinfo.get_disks(): table`
+**Live.** Returns an array of disk tables, one per mounted disk:
+
+```lua
+{
+    {
+        name            = "nvme0n1p2",
+        mount_point     = "/",
+        file_system     = "ext4",
+        kind            = "SSD",   -- "SSD", "HDD", or "Unknown"
+        total_space     = 512110190592, -- bytes
+        available_space = 274877906944, -- bytes
+        removable       = false,
+        read_only       = false,
+    },
+    ...
+}
+```
+
+Never raises. An empty table is possible in containerised environments — overlay filesystems often aren't listed as disks — so don't assume at least one entry when running under Docker/Pterodactyl-style hosting.
+
 ### `sysinfo.get_system_name(): string`
 **Static.** Returns the system name.
 

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -161,6 +161,31 @@ return {
             end
         },
         {
+            name = "Reports disks as a table of well-formed disk entries, never raising",
+            func = function()
+                -- May legitimately be empty in containers (overlay
+                -- filesystems aren't listed as disks), so only the shape of
+                -- present entries is asserted, not a minimum count.
+                local disks = sysinfo.get_disks()
+                expect(disks).to.beA("table")
+
+                for _, disk in ipairs(disks) do
+                    expect(disk.name).to.beA("string")
+                    expect(disk.mount_point).to.beA("string")
+                    expect(#disk.mount_point).to.beGreaterThan(0)
+                    expect(disk.file_system).to.beA("string")
+                    expect(disk.kind).to.beA("string")
+                    expect(disk.total_space).to.beA("number")
+                    expect(disk.available_space).to.beA("number")
+                    expect(disk.total_space).toNot.beLessThan(0)
+                    expect(disk.available_space).toNot.beLessThan(0)
+                    expect(disk.available_space).toNot.beGreaterThan(disk.total_space)
+                    expect(disk.removable).to.beA("boolean")
+                    expect(disk.read_only).to.beA("boolean")
+                end
+            end
+        },
+        {
             name = "Reports its own version as a non-empty string",
             func = function()
                 local version = sysinfo.get_version()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@ use std::time::Instant;
 use gmod::lua::{LuaString, State};
 use gmod::{gmod13_close, gmod13_open, lua_function, lua_string};
 use sysinfo::{
-    CpuRefreshKind, MemoryRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL,
+    CpuRefreshKind, DiskRefreshKind, Disks, MemoryRefreshKind, RefreshKind, System,
+    MINIMUM_CPU_UPDATE_INTERVAL,
 };
 
 mod build_info {
@@ -98,6 +99,36 @@ fn with_cpu<T>(f: impl FnOnce(&System) -> T) -> T {
         cache.last_cpu_refresh = Some(Instant::now());
     }
     f(&cache.system)
+}
+
+/// Separate from `Cache`: disks live in their own sysinfo collection, not on
+/// `System`. Same throttle interval as the rest for consistency.
+struct DisksCache {
+    disks: Disks,
+    last_refresh: Option<Instant>,
+}
+
+static DISKS: LazyLock<Mutex<DisksCache>> = LazyLock::new(|| {
+    Mutex::new(DisksCache {
+        disks: Disks::new(),
+        last_refresh: None,
+    })
+});
+
+fn with_disks<T>(f: impl FnOnce(&Disks) -> T) -> T {
+    let mut cache = DISKS.lock().unwrap_or_else(|e| e.into_inner());
+    if cache
+        .last_refresh
+        .is_none_or(|t| t.elapsed() >= MINIMUM_CPU_UPDATE_INTERVAL)
+    {
+        // io_usage left off: I/O counters are diff-based like CPU usage and
+        // aren't exposed yet, so there's no point paying for them.
+        cache
+            .disks
+            .refresh_specifics(true, DiskRefreshKind::nothing().with_kind().with_storage());
+        cache.last_refresh = Some(Instant::now());
+    }
+    f(&cache.disks)
 }
 
 #[lua_function]
@@ -202,6 +233,35 @@ unsafe fn get_load_average(lua: State) -> i32 {
     lua.set_field(-2, lua_string!("five"));
     lua.push_number(avg.fifteen);
     lua.set_field(-2, lua_string!("fifteen"));
+    1
+}
+
+#[lua_function]
+unsafe fn get_disks(lua: State) -> i32 {
+    with_disks(|disks| {
+        let list = disks.list();
+        lua.create_table(list.len() as i32, 0);
+        for (i, disk) in list.iter().enumerate() {
+            lua.create_table(0, 8);
+            lua.push_string(&disk.name().to_string_lossy());
+            lua.set_field(-2, lua_string!("name"));
+            lua.push_string(&disk.mount_point().to_string_lossy());
+            lua.set_field(-2, lua_string!("mount_point"));
+            lua.push_string(&disk.file_system().to_string_lossy());
+            lua.set_field(-2, lua_string!("file_system"));
+            lua.push_string(&disk.kind().to_string());
+            lua.set_field(-2, lua_string!("kind"));
+            lua.push_number(disk.total_space() as f64);
+            lua.set_field(-2, lua_string!("total_space"));
+            lua.push_number(disk.available_space() as f64);
+            lua.set_field(-2, lua_string!("available_space"));
+            lua.push_boolean(disk.is_removable());
+            lua.set_field(-2, lua_string!("removable"));
+            lua.push_boolean(disk.is_read_only());
+            lua.set_field(-2, lua_string!("read_only"));
+            lua.raw_seti(-2, (i + 1) as i32);
+        }
+    });
     1
 }
 
@@ -334,7 +394,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 22);
+    lua.create_table(0, 23);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
@@ -350,6 +410,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     export_lua_function!(get_distro_id);
     export_lua_function!(get_distro_id_like);
     export_lua_function!(get_load_average);
+    export_lua_function!(get_disks);
     export_lua_function!(get_system_name);
     export_lua_function!(get_system_long_version);
     export_lua_function!(get_system_version);

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -99,6 +99,22 @@ function sysinfo.get_distro_id_like() end
 --- @return SysinfoLoadAverage
 function sysinfo.get_load_average() end
 
+--- @class SysinfoDisk
+--- @field name string
+--- @field mount_point string
+--- @field file_system string # e.g. "ext4", "NTFS"
+--- @field kind "SSD"|"HDD"|"Unknown"
+--- @field total_space number # bytes
+--- @field available_space number # bytes
+--- @field removable boolean
+--- @field read_only boolean
+
+--- Returns an array of mounted disks. Never raises. Live -- read fresh from
+--- the OS each call (internally throttled). May be empty in containerised
+--- environments where overlay filesystems aren't listed as disks.
+--- @return SysinfoDisk[]
+function sysinfo.get_disks() end
+
 --- Returns the system name.
 --- Raises a Lua error if the system name could not be read.
 --- @return string


### PR DESCRIPTION
Draft — the last metric family from #15 (disk metrics).

## API

`sysinfo.get_disks(): table` — **Live**, never raises. Array of disk tables:

```lua
{
    name            = "nvme0n1p2",
    mount_point     = "/",
    file_system     = "ext4",
    kind            = "SSD",        -- "SSD" | "HDD" | "Unknown"
    total_space     = 512110190592, -- bytes
    available_space = 274877906944, -- bytes
    removable       = false,
    read_only       = false,
}
```

## Design notes

- **Own throttled cache** (`DisksCache`), not folded into the existing `Cache` — disks live in sysinfo's separate `Disks` collection, not on `System`. Same `MINIMUM_CPU_UPDATE_INTERVAL` throttle as the other live getters for consistency.
- Refresh runs with `remove_not_listed_disks = true` and skips `io_usage` — I/O counters are diff-based like CPU usage, and nothing exposes them yet, so no point paying for them. If per-disk read/write counters are ever wanted, that's a follow-up with the same first-call-unreliable caveat as `get_cpu_usage()`.
- **Container caveat, documented and tested**: overlay filesystems often aren't listed as disks, so an empty array is a legitimate result under Docker/Pterodactyl-style hosting. The GluaTest case asserts the shape of present entries (including `available <= total`), not a minimum count — same reasoning as the swap tests.
- `sysinfo` dependency gains the `disk` feature; no new crates enter the lockfile (it lights up feature flags on the already-present platform crates).

## Verification

- clippy `-D warnings` both realms, fmt clean, release build links (win64)
- API signatures taken from the installed sysinfo 0.39.6 source directly (`src/common/disk.rs`), not docs
- LuaLS stub (`SysinfoDisk` class) and README entry included

Closes the remaining scope of #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
