### PR TITLE
fix(ci): correct SBOM filename, add tag-triggered republish for recovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref to build. Defaults to the ref that triggered this run.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -27,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       # rustup reads rust-toolchain.toml: pinned nightly, components, targets.
       - name: Install toolchain

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,17 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Existing release tag to (re)publish assets for, e.g. v3.0.0.
+          Rebuilds and republishes without waiting for a new version --
+          the recovery path when package-assets fails after the tag and
+          binaries already exist (its own steps are individually safe to
+          repeat: --clobber on upload, draft=false is idempotent).
+        required: true
+        type: string
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -12,7 +23,7 @@ jobs:
   # until that PR is merged, so "not ready" is simply "don't merge it yet".
   release-pr:
     name: Open release PR
-    if: github.repository_owner == 'JoshPiper'
+    if: github.event_name == 'push' && github.repository_owner == 'JoshPiper'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,7 +51,7 @@ jobs:
   # release. On ordinary pushes this is a no-op (releases_created = false).
   release:
     name: Tag and create release
-    if: github.repository_owner == 'JoshPiper'
+    if: github.event_name == 'push' && github.repository_owner == 'JoshPiper'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -68,13 +79,15 @@ jobs:
   build-assets:
     name: Build release assets
     needs: release
-    if: needs.release.outputs.releases_created == 'true'
+    if: always() && (needs.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/build.yml
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
 
   package-assets:
     name: Provenance, SBOM, and publish
     needs: [release, build-assets]
-    if: needs.release.outputs.releases_created == 'true'
+    if: always() && needs.build-assets.result == 'success' && (needs.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: write # upload release assets, undraft the release
@@ -84,10 +97,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.sha }}
 
       - name: Determine tag
         id: tag
-        run: echo "tag=v$(grep -m1 '^version' Cargo.toml | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=v$(grep -m1 '^version' Cargo.toml | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install toolchain
         run: rustup toolchain install
@@ -108,7 +128,10 @@ jobs:
 
       - name: Assemble release assets
         run: |
-          mv bom.json "assets/gm_sysinfo-${{ steps.tag.outputs.tag }}.cdx.json"
+          # cargo-cyclonedx names its output after the crate, not "bom.json"
+          # (verified against the actual installed binary -- the crate's own
+          # docs say otherwise but are wrong, or at least out of date).
+          mv gm_sysinfo.cdx.json "assets/gm_sysinfo-${{ steps.tag.outputs.tag }}.cdx.json"
           cp sysinfo.lua assets/sysinfo.lua
           (cd assets && sha256sum -- * > SHA256SUMS)
 


### PR DESCRIPTION
Why v3.0.0 is a draft release with a tag, 10 successfully-built binaries sitting as workflow artifacts, and zero attached assets.

## Root cause

`package-assets`'s "Assemble release assets" step ran `mv bom.json ...`. `cargo cyclonedx --format json` never wrote that file -- verified by installing the real binary and running it against this repo at the v3.0.0 tag:

```
$ cargo cyclonedx --format json --verbose
[...] Outputting C:\...\gm_sysinfo.cdx.json
```

It names output `<crate-name>.cdx.json`. The "Generate SBOM" step itself reports success (cargo-cyclonedx doesn't error when nothing consumes its output), so the failure only surfaces one step later at the `mv`. My original source for the `bom.json` name was cargo-cyclonedx's docs, read during P2 -- wrong, or stale for the installed version. Fixed to reference the actual output filename.

## Why fixing the bug alone doesn't recover v3.0.0

- Rerunning the failed job replays the workflow file **as it existed at that run's trigger commit** -- a rerun cannot pick up this fix.
- A new push to main won't retrigger asset building either: `release-plz release` already sees `v3.0.0` as tagged and correctly does nothing (`nothing to release` is the *correct* answer this time).

So there was no existing path back to a released v3.0.0 without either hand-assembling it outside CI (which would mean no real build attestation -- undermining the whole point of P2) or adding one.

## The fix: `workflow_dispatch` with a `tag` input

- `release-pr`/`release` gain `github.event_name == 'push'` so they never fire on manual dispatch.
- `build-assets`/`package-assets` now also run when `github.event_name == 'workflow_dispatch'`, checking out the given tag and rebuilding all 10 binaries fresh -- real CI provenance, not assets assembled by hand.
- `build.yml` gains an optional `ref` input (defaults to `github.sha`, so `ci.yml`'s existing no-argument call is unaffected) so the rebuild actually happens at the right commit instead of wherever `main` currently points.
- Every step in `package-assets` was already idempotent by design (`--clobber` on upload, `draft=false` re-edit) -- this makes that property actually reachable, and gives this failure class (tag+build succeed, final publish step breaks) a real recovery path instead of a one-off manual fix each time.

## After merge

Plan to dispatch this workflow with `tag: v3.0.0` to complete the release end-to-end -- new build, real SBOM under the right name, real attestation, assets attached, undrafted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
