### PR TITLE
chore: release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/JoshPiper/gm_sysinfo/compare/v3.0.0...v3.0.1) - 2026-08-13
+
+### Fixed
+
+- *(ci)* correct SBOM filename, add tag-triggered republish for recovery
+
 ## [3.0.0](https://github.com/JoshPiper/gm_sysinfo/compare/v2.0.0...v3.0.0) - 2026-08-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "gm_sysinfo"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "built",
  "gmod",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gm_sysinfo"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 description = "Garry's Mod binary module exposing system information to Lua"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gm_sysinfo`: 3.0.0 -> 3.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.1](https://github.com/JoshPiper/gm_sysinfo/compare/v3.0.0...v3.0.1) - 2026-08-13

### Fixed

- *(ci)* correct SBOM filename, add tag-triggered republish for recovery
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).