### PR TITLE
Add get_cpu_name and get_cpu_brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ local mib = math.floor(sysinfo.get_memory() / 1024 / 1024)
 ### `sysinfo.get_cpu_arch(): string`
 **Static.** Returns the CPU architecture (e.g. `"x86_64"`). Never raises.
 
+### `sysinfo.get_cpu_name(): string`
+**Static.** Returns the first CPU's identifier as reported by the OS (e.g. `"cpu0"` on Linux). Raises if it couldn't be read.
+
+### `sysinfo.get_cpu_brand(): string`
+**Static.** Returns the first CPU's brand/model string (e.g. `"Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz"`). Raises if it couldn't be read.
+
 ### `sysinfo.get_distro_id(): string`
 **Static.** Despite the name, not Linux-specific: on Linux it's the distribution id (e.g. `"ubuntu"`); elsewhere it falls back to a normalized platform name (`"windows"`, `"macos"`). Never raises.
 

--- a/lua/tests/sysinfo/sysinfo_test.lua
+++ b/lua/tests/sysinfo/sysinfo_test.lua
@@ -115,6 +115,8 @@ return {
                     "get_system_long_version",
                     "get_kernel_version",
                     "get_host_name",
+                    "get_cpu_name",
+                    "get_cpu_brand",
                 }
 
                 for _, name in ipairs( getters ) do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,17 @@ struct Snapshot {
     os_version: String,
     kernel_version: String,
     host_name: String,
+    cpu_name: String,
+    cpu_brand: String,
 }
 
 static INFO: LazyLock<Snapshot> = LazyLock::new(|| {
     let sys = System::new_with_specifics(
-        RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+        RefreshKind::nothing()
+            .with_memory(MemoryRefreshKind::everything())
+            .with_cpu(CpuRefreshKind::everything()),
     );
+    let cpu = sys.cpus().first();
     Snapshot {
         cores: System::physical_core_count().unwrap_or_default(),
         total_memory: sys.total_memory(),
@@ -48,6 +53,8 @@ static INFO: LazyLock<Snapshot> = LazyLock::new(|| {
         os_version: System::os_version().unwrap_or_default(),
         kernel_version: System::kernel_version().unwrap_or_default(),
         host_name: System::host_name().unwrap_or_default(),
+        cpu_name: cpu.map(|c| c.name().to_owned()).unwrap_or_default(),
+        cpu_brand: cpu.map(|c| c.brand().to_owned()).unwrap_or_default(),
     }
 });
 
@@ -180,6 +187,26 @@ unsafe fn get_cpu_arch(lua: State) -> i32 {
     // Always populated: sysinfo falls back to the build's target arch if the
     // OS query fails.
     lua.push_string(&System::cpu_arch());
+    1
+}
+
+#[lua_function]
+unsafe fn get_cpu_name(lua: State) -> i32 {
+    if INFO.cpu_name.is_empty() {
+        error(lua, err!("read the CPU name"));
+    }
+
+    lua.push_string(&INFO.cpu_name);
+    1
+}
+
+#[lua_function]
+unsafe fn get_cpu_brand(lua: State) -> i32 {
+    if INFO.cpu_brand.is_empty() {
+        error(lua, err!("read the CPU brand"));
+    }
+
+    lua.push_string(&INFO.cpu_brand);
     1
 }
 
@@ -334,7 +361,7 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     LazyLock::force(&INFO);
 
     // Create _G.sysinfo
-    lua.create_table(0, 22);
+    lua.create_table(0, 24);
     export_lua_function!(get_core_count);
     export_lua_function!(get_memory);
     export_lua_function!(get_swap);
@@ -347,6 +374,8 @@ unsafe fn gmod13_open(lua: State) -> i32 {
     export_lua_function!(get_boot_time);
     export_lua_function!(get_cpu_usage);
     export_lua_function!(get_cpu_arch);
+    export_lua_function!(get_cpu_name);
+    export_lua_function!(get_cpu_brand);
     export_lua_function!(get_distro_id);
     export_lua_function!(get_distro_id_like);
     export_lua_function!(get_load_average);

--- a/sysinfo.lua
+++ b/sysinfo.lua
@@ -72,6 +72,16 @@ function sysinfo.get_cpu_usage() end
 --- @return string
 function sysinfo.get_cpu_arch() end
 
+--- Returns the first CPU's identifier as reported by the OS (e.g. "cpu0" on
+--- Linux). Raises if it couldn't be read.
+--- @return string
+function sysinfo.get_cpu_name() end
+
+--- Returns the first CPU's brand/model string, e.g.
+--- "Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz". Raises if it couldn't be read.
+--- @return string
+function sysinfo.get_cpu_brand() end
+
 --- Despite the name, not Linux-specific: on Linux this is the distribution
 --- id (e.g. "ubuntu"); elsewhere it falls back to a normalized platform name
 --- ("windows", "macos"). Never raises.


### PR DESCRIPTION
## Summary
- Adds `sysinfo.get_cpu_name()` and `sysinfo.get_cpu_brand()`, exposing the first CPU's OS-reported identifier and brand/model string (e.g. `"Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz"`)
- Static, snapshotted once at module load like the other identity getters (`get_host_name`, `get_system_name`, etc.), raising if the value couldn't be read

## Test plan
- [x] `cargo build` succeeds
- [x] Extended the existing identity-getter GLuaTest case to cover both new getters (runs in CI's GMod Docker harness)
- [x] README and LuaLS type stubs updated